### PR TITLE
Fix WebAssembly.Module.imports TypeError on Safari with workaround

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script src="src/wasm-webkit-patch.js"></script>
     <title>mcsrc</title>
   </head>
   <body>

--- a/src/wasm-webkit-patch.js
+++ b/src/wasm-webkit-patch.js
@@ -1,0 +1,13 @@
+if (typeof WebAssembly !== "undefined" && WebAssembly.Module?.imports) {
+	const originalImports = WebAssembly.Module.imports;
+	WebAssembly.Module.imports = function patchedImports(module) {
+		try {
+			return originalImports.call(WebAssembly.Module, module);
+		} catch (err) {
+			if (!("__wasmImportsPatched" in globalThis)) {
+				globalThis.__wasmImportsPatched = true;
+			}
+			return [{module: "teavm", name: "memory", kind: "memory"}];
+		}
+	};
+}


### PR DESCRIPTION
Adds a shim to return what is expected by `@run-slicer/vf/vf.wasm-runtime.js` when importing. Seems to work fine on WebKit browsers and doesn't require proxying the entire wasm runtime ... yet.