### PR TITLE
Set monaco tabSize to 3

### DIFF
--- a/src/ui/Code.tsx
+++ b/src/ui/Code.tsx
@@ -11,7 +11,7 @@ const Code = () => {
             defaultLanguage="java"
             theme="vs-dark"
             value={src}
-            options={{ readOnly: true }} />
+            options={{ readOnly: true, tabSize: 3 }} />
     );
 }
 


### PR DESCRIPTION
Sets the monaco option `tabSize` to 3, to match the indentation of the decompiled code.

|Before|After|
|---|---|
|<img width="433" height="424" alt="chrome_ggItNBxZY8" src="https://github.com/user-attachments/assets/28e2966a-5222-4111-8dd1-56e33a5379ed" />|<img width="486" height="426" alt="chrome_8lKCixvHEm" src="https://github.com/user-attachments/assets/370cb604-5986-4c00-9aeb-224e1e4d1bf1" />|