### PR TITLE
[Issue][54] - Set select item width to fit-content.

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -76,3 +76,7 @@ html, body {margin: 0; height: 100%; overflow: hidden}
   background-color: rgba(255, 255, 100, 0.3) !important;
   width: 4px !important;
 }
+
+.ant-select-selection-item {
+  width: fit-content !important;
+}


### PR DESCRIPTION
Issue - [54](https://github.com/FabricMC/mcsrc/issues/54)
Added CSS rule to ensure .ant-select-selection-item uses fit-content width, improving layout for select components.

<img width="239" height="328" alt="Screenshot 2026-01-12 at 17 45 18" src="https://github.com/user-attachments/assets/7c30d2a1-d537-4aec-96e2-2cb70cf5e0f3" />
