### PR TITLE
[Chore] - Convert file tree CSS comments to block comments.

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -77,13 +77,13 @@ html, body {margin: 0; height: 100%; overflow: hidden}
   width: 4px !important;
 }
 
-// Stop icon & text in file tree from wrapping
+/* Stop icon & text in file tree from wrapping */
 .ant-tree-node-content-wrapper {
     display: flex;
     flex-wrap: nowrap;
 }
 
-// Stop text in file tree from wrapping
+/* Stop text in file tree from wrapping */
 .ant-tree-title {
     white-space: nowrap;
 }


### PR DESCRIPTION
<img width="1049" height="242" alt="Screenshot 2026-01-14 at 10 51 49" src="https://github.com/user-attachments/assets/28128579-5a32-4a2d-bf15-deea9cc53191" />

This pull request makes a minor change to the `src/index.css` file, converting some inline comments from Sass/LESS-style (`//`) to standard CSS block comments (`/* ... */`). This improves compatibility and clarity in the stylesheet.
