### PR TITLE
Rename "Find Usages" to "Find All References" for consistency with vscode

### DIFF
--- a/java/src/main/java/mcsrc/ClassIndexVisitor.java
+++ b/java/src/main/java/mcsrc/ClassIndexVisitor.java
@@ -131,7 +131,7 @@ public class ClassIndexVisitor extends ClassVisitor {
 		}
 
 		if (type.getSort() == Type.OBJECT) {
-			Indexer.addUsage(type.getInternalName(), method.usage());
+			Indexer.addReference(type.getInternalName(), method.reference());
 		}
 	}
 
@@ -144,23 +144,23 @@ public class ClassIndexVisitor extends ClassVisitor {
 		}
 
 		if (type.getSort() == Type.OBJECT) {
-			Indexer.addUsage(type.getInternalName(), field.usage());
+			Indexer.addReference(type.getInternalName(), field.reference());
 		}
 	}
 
 	public void indexClassReference(Entry.Method callerEntry, Entry.Class referencedEntry) {
-		Indexer.addUsage(referencedEntry.name(), callerEntry.usage());
+		Indexer.addReference(referencedEntry.name(), callerEntry.reference());
 	}
 
 	public void indexMethodReference(Entry.Method callerEntry, Entry.Method referencedEntry) {
-		Indexer.addUsage(referencedEntry.str(), callerEntry.usage());
+		Indexer.addReference(referencedEntry.str(), callerEntry.reference());
 
 		if (referencedEntry.name().equals("<init>")) {
-			Indexer.addUsage(referencedEntry.owner(), callerEntry.usage());
+			Indexer.addReference(referencedEntry.owner(), callerEntry.reference());
 		}
 	}
 
 	public void indexFieldReference(Entry.Method callerEntry, Entry.Field referencedEntry) {
-		Indexer.addUsage(referencedEntry.str(), callerEntry.usage());
+		Indexer.addReference(referencedEntry.str(), callerEntry.reference());
 	}
 }

--- a/java/src/main/java/mcsrc/Entry.java
+++ b/java/src/main/java/mcsrc/Entry.java
@@ -1,11 +1,11 @@
 package mcsrc;
 
 public sealed interface Entry permits Entry.Class, Entry.Member, Entry.Field, Entry.Method {
-    String usage();
+    String reference();
 
     record Class(String name) implements Entry {
         @Override
-        public String usage() {
+        public String reference() {
             return "s:%s".formatted(name);
         }
     }
@@ -19,7 +19,7 @@ public sealed interface Entry permits Entry.Class, Entry.Member, Entry.Field, En
         }
 
         @Override
-        public String usage() {
+        public String reference() {
             return "f:%s:%s:%s".formatted(owner, name, desc);
         }
     }
@@ -30,7 +30,7 @@ public sealed interface Entry permits Entry.Class, Entry.Member, Entry.Field, En
         }
 
         @Override
-        public String usage() {
+        public String reference() {
             return "m:%s:%s:%s".formatted(owner, name, desc);
         }
     }

--- a/java/src/main/java/mcsrc/Indexer.java
+++ b/java/src/main/java/mcsrc/Indexer.java
@@ -13,8 +13,8 @@ import java.io.StringWriter;
 import java.util.*;
 
 public class Indexer {
-    private static final Map<String, Set<String>> usages = new HashMap<>();
-    private static int usageSize = 0;
+    private static final Map<String, Set<String>> references = new HashMap<>();
+    private static int referenceSize = 0;
     
     private static final Map<String, ClassInheritanceInfo> inheritanceData = new HashMap<>();
 
@@ -27,13 +27,13 @@ public class Indexer {
     }
 
     @JSExport
-    public static String[] getUsage(String key) {
-        return usages.getOrDefault(key, Set.of()).toArray(String[]::new);
+    public static String[] getReference(String key) {
+        return references.getOrDefault(key, Set.of()).toArray(String[]::new);
     }
 
     @JSExport
-    public static int getUsageSize() {
-        return usageSize;
+    public static int getReferenceSize() {
+        return referenceSize;
     }
 
     @JSExport
@@ -56,13 +56,13 @@ public class Indexer {
         return result.toString();
     }
 
-    public static void addUsage(String key, String value) {
+    public static void addReference(String key, String value) {
         if (!isMinecraft(key)) {
             return;
         }
 
-        usages.computeIfAbsent(key, k -> new HashSet<>()).add(value);
-        usageSize++;
+        references.computeIfAbsent(key, k -> new HashSet<>()).add(value);
+        referenceSize++;
     }
 
     private static boolean isMinecraft(String str) {

--- a/src/logic/FindAllReferences.ts
+++ b/src/logic/FindAllReferences.ts
@@ -1,11 +1,11 @@
 import { BehaviorSubject, combineLatest, distinctUntilChanged, from, map, Observable, switchMap, throttleTime } from "rxjs";
-import { jarIndex, type UsageKey, type UsageString } from "../workers/JarIndex";
+import { jarIndex, type ReferenceKey, type ReferenceString } from "../workers/JarIndex";
 import { openTab } from "./Tabs";
-import { usageQuery } from "./State";
+import { referencesQuery } from "./State";
 import type { Token } from "./Tokens";
 import type { DecompileResult } from "../workers/decompile/types";
 
-export const useageResults = usageQuery
+export const referenceResults = referencesQuery
     .pipe(
         throttleTime(200),
         distinctUntilChanged(),
@@ -14,32 +14,32 @@ export const useageResults = usageQuery
                 return from([[]]);
             }
             return jarIndex.pipe(
-                switchMap((index) => from(index.getUsage(query)))
+                switchMap((index) => from(index.getReference(query)))
             );
         })
     );
 
-export const isViewingUsages = usageQuery.pipe(
+export const isViewingReferences = referencesQuery.pipe(
     map((query) => query.length > 0)
 );
 
-// Format the usage string to be displayed by the user
-export function formatUsage(usage: UsageString): string {
-    if (usage.startsWith("m:")) {
-        const parts = usage.slice(2).split(":");
+// Format the reference string to be displayed by the user
+export function formatReference(reference: ReferenceString): string {
+    if (reference.startsWith("m:")) {
+        const parts = reference.slice(2).split(":");
         return `${parts[1]}${parts[2]}`;
     }
-    if (usage.startsWith("f:")) {
-        const parts = usage.slice(2).split(":");
+    if (reference.startsWith("f:")) {
+        const parts = reference.slice(2).split(":");
         return parts[1];
     }
-    if (usage.startsWith("c:")) {
-        return usage.slice(2);
+    if (reference.startsWith("c:")) {
+        return reference.slice(2);
     }
-    return usage;
+    return reference;
 }
 
-export function formatUsageQuery(query: UsageKey): string {
+export function formatReferenceQuery(query: ReferenceKey): string {
     const type = getQueryType(query);
 
     switch (type) {
@@ -58,7 +58,7 @@ export function formatUsageQuery(query: UsageKey): string {
     }
 }
 
-function getQueryType(query: UsageKey): "class" | "method" | "field" {
+function getQueryType(query: ReferenceKey): "class" | "method" | "field" {
     if (query.includes(":")) {
         const parts = query.split(":");
         if (parts[2].includes("(")) {
@@ -70,57 +70,57 @@ function getQueryType(query: UsageKey): "class" | "method" | "field" {
     return "class";
 }
 
-interface UsageNavigation {
+interface ReferenceNavigation {
     // The class to navigate to
     className: string;
-    // The usage being navigated to
-    query: UsageKey;
-    // The location of where the usage is found
-    usage: UsageString;
+    // The reference being navigated to
+    query: ReferenceKey;
+    // The location of where the reference is found
+    reference: ReferenceString;
 }
 
-export const nextUsageNavigation = new BehaviorSubject<UsageNavigation | undefined>(undefined);
+export const nextReferenceNavigation = new BehaviorSubject<ReferenceNavigation | undefined>(undefined);
 
-export function goToUsage(query: UsageKey, usage: UsageString) {
-    const className = usage.slice(2).split(":")[0].split('$')[0];
+export function goToReference(query: ReferenceKey, reference: ReferenceString) {
+    const className = reference.slice(2).split(":")[0].split('$')[0];
     openTab(className + ".class");
 
-    if (usage.startsWith("c:")) {
+    if (reference.startsWith("c:")) {
         // Nothing to jump to
         return;
     }
 
-    nextUsageNavigation.next({ className, query, usage });
+    nextReferenceNavigation.next({ className, query, reference });
 }
 
 export function getNextJumpToken(decompileResult: DecompileResult): Token | undefined {
-    const usageNavigation = nextUsageNavigation.getValue();
+    const referenceNavigation = nextReferenceNavigation.getValue();
 
-    if (!usageNavigation) {
+    if (!referenceNavigation) {
         return undefined;
     }
 
-    const { className, query, usage } = usageNavigation;
+    const { className, query, reference } = referenceNavigation;
 
     if (decompileResult.className != className) {
-        console.log("Decompile result class does not match usage navigation class", decompileResult.className, className);
+        console.log("Decompile result class does not match reference navigation class", decompileResult.className, className);
         return undefined;
     }
 
-    nextUsageNavigation.next(undefined);
+    nextReferenceNavigation.next(undefined);
 
-    // This works by first finding the token that matches the usage we are looking for.
+    // This works by first finding the token that matches the reference we are looking for.
     // We can then find the token that matches the declaration of the query we are looking for.
-    // This allows us to jump to the first usage of the query after the usage that was selected.
+    // This allows us to jump to the first reference of the query after the reference that was selected.
 
-    let usageTokenIndex: number | null = null;
+    let referenceTokenIndex: number | null = null;
 
-    { // First find the usage token
-        const parts = usage.slice(2).split(":");
+    { // First find the reference token
+        const parts = reference.slice(2).split(":");
         const classname = parts[0];
         const name = parts[1];
         const descriptor = parts[2];
-        const expectedType = usage.startsWith("m:") ? "method" : "field";
+        const expectedType = reference.startsWith("m:") ? "method" : "field";
 
         for (let i = 0; i < decompileResult.tokens.length; i++) {
             const token = decompileResult.tokens[i];
@@ -136,7 +136,7 @@ export function getNextJumpToken(decompileResult: DecompileResult): Token | unde
 
             if (token.className == classname && token.name == name && token.descriptor == descriptor) {
                 if (token.type == "field") {
-                    // For fields, just return the usage as there is only one declaration
+                    // For fields, just return the reference as there is only one declaration
                     return token;
                 }
 
@@ -147,14 +147,14 @@ export function getNextJumpToken(decompileResult: DecompileResult): Token | unde
                 }
 
                 // For methods we can keep looking for a token that matches the query after this
-                usageTokenIndex = i;
+                referenceTokenIndex = i;
                 break;
             }
         }
     }
 
-    if (!usageTokenIndex) {
-        console.log("Could not find usage token for", usage);
+    if (!referenceTokenIndex) {
+        console.log("Could not find reference token for", reference);
         return undefined;
     }
 
@@ -163,11 +163,11 @@ export function getNextJumpToken(decompileResult: DecompileResult): Token | unde
     const descriptor = parts[2];
     const queryType = getQueryType(query);
 
-    // Next continue searching from the usage token index to find the actual useage
-    for (let i = usageTokenIndex + 1; i < decompileResult.tokens.length; i++) {
+    // Next continue searching from the reference token index to find the actual reference
+    for (let i = referenceTokenIndex + 1; i < decompileResult.tokens.length; i++) {
         const token = decompileResult.tokens[i];
 
-        // Special case for constructor usage
+        // Special case for constructor reference
         if (name == "<init>" && token.type == "class" && token.className == parts[0]) {
             return token;
         }
@@ -182,7 +182,7 @@ export function getNextJumpToken(decompileResult: DecompileResult): Token | unde
     }
 
     // Give up if we reach another declaration, it means we didnt find it
-    // Just return the declaration that supposedly contains the usage
+    // Just return the declaration that supposedly contains the reference
     console.log("Could not find token for", query);
-    return decompileResult.tokens[usageTokenIndex];
+    return decompileResult.tokens[referenceTokenIndex];
 }

--- a/src/logic/State.ts
+++ b/src/logic/State.ts
@@ -13,7 +13,7 @@ export const selectedFile = new BehaviorSubject<string>(initialState.file);
 export const openTabs = new BehaviorSubject<Tab[]>([new Tab(initialState.file)]);
 export const tabHistory = new BehaviorSubject<string[]>([initialState.file]);
 export const searchQuery = new BehaviorSubject("");
-export const usageQuery = new BehaviorSubject("");
+export const referencesQuery = new BehaviorSubject("");
 
 export interface SelectedLines {
   line: number;

--- a/src/types/java-indexer.d.ts
+++ b/src/types/java-indexer.d.ts
@@ -2,8 +2,8 @@
 
 declare module "*/java.js" {
     export function index(data: ArrayBufferLike): void;
-    export function getUsage(key: string): string[];
-    export function getUsageSize(): number;
+    export function getReference(key: string): string[];
+    export function getReferenceSize(): number;
     export function getBytecode(classData: ArrayBufferLike[]): string;
     export function getClassData(): string[];
 }

--- a/src/ui/CodeContextActions.ts
+++ b/src/ui/CodeContextActions.ts
@@ -9,9 +9,9 @@ async function setClipboard(text: string): Promise<void> {
 }
 
 export function createCopyAwAction(
-    decompileResultRef: { current: DecompileResult | undefined },
-    classListRef: { current: string[] | undefined },
-    messageApi: { error: (msg: string) => void; success: (msg: string) => void }
+    decompileResultRef: { current: DecompileResult | undefined; },
+    classListRef: { current: string[] | undefined; },
+    messageApi: { error: (msg: string) => void; success: (msg: string) => void; }
 ) {
     return {
         id: 'copy_aw',
@@ -46,9 +46,9 @@ export function createCopyAwAction(
 }
 
 export function createCopyMixinAction(
-    decompileResultRef: { current: DecompileResult | undefined },
-    classListRef: { current: string[] | undefined },
-    messageApi: { error: (msg: string) => void; success: (msg: string) => void }
+    decompileResultRef: { current: DecompileResult | undefined; },
+    classListRef: { current: string[] | undefined; },
+    messageApi: { error: (msg: string) => void; success: (msg: string) => void; }
 ) {
     return {
         id: 'copy_mixin',
@@ -82,34 +82,34 @@ export function createCopyMixinAction(
     };
 }
 
-export function createFindUsagesAction(
-    decompileResultRef: { current: DecompileResult | undefined },
-    classListRef: { current: string[] | undefined },
-    messageApi: { error: (msg: string) => void },
-    usageQueryNext: (value: string) => void
+export function createFindAllReferencesAction(
+    decompileResultRef: { current: DecompileResult | undefined; },
+    classListRef: { current: string[] | undefined; },
+    messageApi: { error: (msg: string) => void; },
+    referenceQueryNext: (value: string) => void
 ) {
     return {
-        id: 'find_usages',
-        label: 'Find Usages',
+        id: 'find_all_references',
+        label: 'Find All References',
         contextMenuGroupId: 'navigation',
         contextMenuOrder: 1,
         precondition: IS_DEFINITION_CONTEXT_KEY_NAME,
         run: async function (editor: editor.ICodeEditor, ...args: any[]): Promise<void> {
             const token = findTokenAtPosition(editor, decompileResultRef.current, classListRef.current);
             if (!token) {
-                messageApi.error("Failed to find token for usages.");
+                messageApi.error("Failed to find token for references.");
                 return;
             }
 
             switch (token.type) {
                 case "class":
-                    usageQueryNext(token.className);
+                    referenceQueryNext(token.className);
                     break;
                 case "field":
-                    usageQueryNext(`${token.className}:${token.name}:${token.descriptor}`);
+                    referenceQueryNext(`${token.className}:${token.name}:${token.descriptor}`);
                     break;
                 case "method":
-                    usageQueryNext(`${token.className}:${token.name}:${token.descriptor}`);
+                    referenceQueryNext(`${token.className}:${token.name}:${token.descriptor}`);
                     break;
                 default:
                     messageApi.error("Token is not a class, field, or method.");
@@ -120,8 +120,8 @@ export function createFindUsagesAction(
 }
 
 export function createViewInheritanceAction(
-    decompileResultRef: { current: DecompileResult | undefined },
-    messageApi: { error: (msg: string) => void },
+    decompileResultRef: { current: DecompileResult | undefined; },
+    messageApi: { error: (msg: string) => void; },
     selectedInheritanceClassNameNext: (value: string) => void
 ) {
     return {

--- a/src/ui/FileList.tsx
+++ b/src/ui/FileList.tsx
@@ -9,7 +9,7 @@ import type { Key } from 'antd/es/table/interface';
 import { openTab } from '../logic/Tabs';
 import { minecraftJar, type MinecraftJar } from '../logic/MinecraftApi';
 import { decompileClass } from '../logic/Decompiler';
-import { selectedFile, usageQuery } from '../logic/State';
+import { selectedFile, referencesQuery } from '../logic/State';
 import { compactPackages } from '../logic/Settings';
 
 const fileTree: Observable<TreeDataNode[]> = combineLatest([
@@ -190,11 +190,11 @@ const getMenuItems = (
             disabled: !isFile
         },
         {
-            key: 'find-usages',
-            label: 'Find Usages',
+            key: 'find-all-references',
+            label: 'Find All References',
             onClick: () => {
                 const cleanPath = path.replace('.class', '');
-                usageQuery.next(cleanPath);
+                referencesQuery.next(cleanPath);
             },
             disabled: !isFile
         },

--- a/src/ui/ReferenceResults.tsx
+++ b/src/ui/ReferenceResults.tsx
@@ -1,11 +1,11 @@
 import { useObservable } from "../utils/UseObservable";
-import { formatUsage, goToUsage, useageResults } from "../logic/FindUsages";
-import type { UsageString } from "../workers/JarIndex";
+import { formatReference, goToReference, referenceResults } from "../logic/FindAllReferences";
+import type { ReferenceString } from "../workers/JarIndex";
 import { map, Observable } from "rxjs";
 import { openTab } from "../logic/Tabs";
-import { usageQuery } from "../logic/State";
+import { referencesQuery } from "../logic/State";
 
-function getUsageClass(usage: UsageString): string {
+function getUsageClass(usage: ReferenceString): string {
     if (usage.startsWith("m:") || usage.startsWith("f:")) {
         const parts = usage.slice(2).split(":");
         return parts[0];
@@ -15,14 +15,14 @@ function getUsageClass(usage: UsageString): string {
     return usage;
 }
 
-interface UsageGroup {
+interface ReferenceGroup {
     className: string;
-    usages: UsageString[];
+    references: ReferenceString[];
 }
 
-const groupedResults: Observable<UsageGroup[]> = useageResults.pipe(
+const groupedResults: Observable<ReferenceGroup[]> = referenceResults.pipe(
     map(results => {
-        const groups: Record<string, UsageString[]> = {};
+        const groups: Record<string, ReferenceString[]> = {};
 
         for (const usage of results) {
             const className = getUsageClass(usage);
@@ -32,19 +32,19 @@ const groupedResults: Observable<UsageGroup[]> = useageResults.pipe(
             groups[className].push(usage);
         }
 
-        return Object.entries(groups).map(([className, usages]) => ({
+        return Object.entries(groups).map(([className, references]) => ({
             className,
-            usages
+            references
         }));
     })
 );
 
 interface UsageGroupItemProps {
-    group: UsageGroup;
+    group: ReferenceGroup;
 }
 
 const UsageGroupItem = ({ group }: UsageGroupItemProps) => {
-    const query = useObservable(usageQuery)!;
+    const query = useObservable(referencesQuery)!;
 
     return (
         <div style={{ marginBottom: "4px" }}>
@@ -63,10 +63,10 @@ const UsageGroupItem = ({ group }: UsageGroupItemProps) => {
                 {group.className}
             </div>
             <div style={{ paddingLeft: "16px" }}>
-                {group.usages.map((usage, index) => (
+                {group.references.map((reference, index) => (
                     <div
                         key={index}
-                        onClick={() => goToUsage(query, usage)}
+                        onClick={() => goToReference(query, reference)}
                         style={{
                             cursor: "pointer",
                             fontSize: "12px",
@@ -76,7 +76,7 @@ const UsageGroupItem = ({ group }: UsageGroupItemProps) => {
                         onMouseEnter={(e) => e.currentTarget.style.backgroundColor = 'rgba(255, 255, 255, 0.05)'}
                         onMouseLeave={(e) => e.currentTarget.style.backgroundColor = 'transparent'}
                     >
-                        {formatUsage(usage)}
+                        {formatReference(reference)}
                     </div>
                 ))}
             </div>

--- a/src/ui/SideBar.tsx
+++ b/src/ui/SideBar.tsx
@@ -5,33 +5,33 @@ import type { InputRef, SearchProps } from "antd/es/input";
 import { useObservable } from "../utils/UseObservable";
 import { isSearching } from "../logic/JarFile";
 import SearchResults from "./SearchResults";
-import UsageResults from "./UsageResults";
-import { formatUsageQuery, isViewingUsages } from "../logic/FindUsages";
+import ReferenceResults from "./ReferenceResults";
+import { formatReferenceQuery, isViewingReferences } from "../logic/FindAllReferences";
 import { ArrowLeftOutlined } from "@ant-design/icons";
 import { focusSearchEvent } from "../logic/Keybinds";
 import { useEffect, useRef } from "react";
-import { searchQuery, usageQuery } from "../logic/State";
+import { searchQuery, referencesQuery } from "../logic/State";
 
 const { Search } = Input;
 
 const SideBar = () => {
-    const showUsage = useObservable(isViewingUsages);
-    const currentUsageQuery = useObservable(usageQuery);
+    const showReference = useObservable(isViewingReferences);
+    const currentReferenceQuery = useObservable(referencesQuery);
     const focusSearch = useObservable(focusSearchEvent);
     const searchRef = useRef<InputRef>(null);
 
     useEffect(() => {
         if (focusSearch) {
-            usageQuery.next("");
+            referencesQuery.next("");
             searchRef?.current?.focus();
         }
     }, [focusSearch]);
 
     useEffect(() => {
-        if (focusSearch && !showUsage) {
+        if (focusSearch && !showReference) {
             searchRef?.current?.focus();
         }
-    }, [focusSearch, showUsage]);
+    }, [focusSearch, showReference]);
 
     const onChange: SearchProps['onChange'] = (e) => {
 
@@ -39,19 +39,19 @@ const SideBar = () => {
     };
 
     const onBackClick = () => {
-        usageQuery.next("");
+        referencesQuery.next("");
     };
 
     return (
         <Flex vertical style={{ height: "100%", padding: "0 4px" }}>
             <Header />
-            {showUsage ? (
+            {showReference ? (
                 <>
                     <Button onClick={onBackClick} icon={<ArrowLeftOutlined />} block>
                         Back
                     </Button>
                     <div style={{ fontSize: "12px", textAlign: "center" }}>
-                        Usages of: {formatUsageQuery(currentUsageQuery || "")}
+                        References of: {formatReferenceQuery(currentReferenceQuery || "")}
                     </div>
                 </>
             ) : (
@@ -67,10 +67,10 @@ const SideBar = () => {
 
 const FileListOrSearchResults = () => {
     const showSearchResults = useObservable(isSearching);
-    const showUsage = useObservable(isViewingUsages);
+    const showReference = useObservable(isViewingReferences);
 
-    if (showUsage) {
-        return <UsageResults />;
+    if (showReference) {
+        return <ReferenceResults />;
     } else if (showSearchResults) {
         return <SearchResults />;
     } else {

--- a/src/workers/JarIndex.ts
+++ b/src/workers/JarIndex.ts
@@ -6,9 +6,9 @@ import type { ClassDataString } from "./JarIndexWorker";
 export type Class = string;
 export type Method = `${string}:${string}:${string}`;
 export type Field = `${string}:${string}:${string}`;
-export type UsageKey = Class | Method | Field;
+export type ReferenceKey = Class | Method | Field;
 
-export type UsageString =
+export type ReferenceString =
     | `c:${Class}`
     | `m:${Method}`
     | `f:${Field}`;
@@ -114,7 +114,7 @@ export class JarIndex {
                         const batch = taskQueue.splice(0, batchSize);
 
                         if (batch.length === 0) {
-                            const indexed = await worker.getUsageSize();
+                            const indexed = await worker.getReferenceSize();
                             resolve(indexed);
                             return;
                         }
@@ -143,13 +143,13 @@ export class JarIndex {
         }
     }
 
-    async getUsage(key: UsageKey): Promise<UsageString[]> {
+    async getReference(key: ReferenceKey): Promise<ReferenceString[]> {
         await this.indexJar();
 
-        let results: Promise<UsageString[]>[] = [];
+        let results: Promise<ReferenceString[]>[] = [];
 
         for (const worker of this.workers) {
-            results.push(worker.getUsage(key));
+            results.push(worker.getReference(key));
         }
 
         return Promise.all(results).then(arrays => arrays.flat());

--- a/src/workers/JarIndexWorker.ts
+++ b/src/workers/JarIndexWorker.ts
@@ -1,7 +1,7 @@
 import { load } from "../../java/build/generated/teavm/wasm-gc/java.wasm-runtime.js";
 import indexerWasm from '../../java/build/generated/teavm/wasm-gc/java.wasm?url';
 import { openJar, type Jar } from "../utils/Jar.js";
-import type { UsageKey, UsageString } from "./JarIndex.js";
+import type { ReferenceKey, ReferenceString } from "./JarIndex.js";
 
 export type ClassDataString = `${string}|${string}|${number}|${string}`;
 
@@ -50,14 +50,14 @@ export const indexBatch = async (classNames: string[]): Promise<void> => {
     }
 };
 
-export const getUsage = async (key: UsageKey): Promise<[UsageString]> => {
+export const getReference = async (key: ReferenceKey): Promise<[ReferenceString]> => {
     const indexer = await getIndexer();
-    return indexer.getUsage(key);
+    return indexer.getReference(key);
 };
 
-export const getUsageSize = async (): Promise<number> => {
+export const getReferenceSize = async (): Promise<number> => {
     const indexer = await getIndexer();
-    return indexer.getUsageSize();
+    return indexer.getReferenceSize();
 };
 
 export const getBytecode = async (classData: ArrayBufferLike[]): Promise<string> => {
@@ -72,8 +72,8 @@ export const getClassData = async (): Promise<ClassDataString[]> => {
 
 interface Indexer {
     index(data: ArrayBufferLike): void;
-    getUsage(key: UsageKey): [UsageString];
-    getUsageSize(): number;
+    getReference(key: ReferenceKey): [ReferenceString];
+    getReferenceSize(): number;
     getBytecode(classData: ArrayBufferLike[]): string;
     getClassData(): ClassDataString[];
 }

--- a/tests/find-usages.spec.ts
+++ b/tests/find-usages.spec.ts
@@ -1,12 +1,12 @@
 import { test, expect } from '@playwright/test';
 import { waitForDecompiledContent, setupTest } from './test-utils';
 
-test.describe('Find Usages', () => {
+test.describe('Find All References', () => {
     test.beforeEach(async ({ page }) => {
         await setupTest(page);
     });
 
-    test('Triggers find usages action', async ({ page }) => {
+    test('Triggers find all references action', async ({ page }) => {
         await page.goto('/');
         await waitForDecompiledContent(page, 'enum ChatFormatting');
 


### PR DESCRIPTION
Monaco usage brings an expectation of being similar to VSCode, those familiar with it will usually prefer consistency