### PR TITLE
Fix sidebar header moving around when the display area is narrow

### DIFF
--- a/src/ui/Header.tsx
+++ b/src/ui/Header.tsx
@@ -1,4 +1,4 @@
-import { Divider, Flex, Select, Space } from "antd";
+import { Divider, Flex, Select } from "antd";
 import { minecraftVersionIds } from "../logic/MinecraftApi";
 import { useObservable } from "../utils/UseObservable";
 import { AboutModalButton } from "./AboutModal";
@@ -9,8 +9,10 @@ import { JarDecompilerModalButton } from "./JarDecompilerModal";
 const Header = () => {
     return (
         <div>
-            <Flex justify="center" style={{ width: '100%', paddingTop: 8 }}>
-                <HeaderBody />
+            <Flex style={{ width: "100%", paddingTop: 8 }}>
+                <div style={{ width: "100%", minWidth: 0, overflowX: "auto", overflowY: "hidden" }}>
+                    <HeaderBody />
+                </div>
             </Flex>
             <Divider size="small" />
         </div>
@@ -21,8 +23,8 @@ const HeaderBody = () => {
     const versions = useObservable(minecraftVersionIds);
     const currentVersion = useObservable(selectedMinecraftVersion);
     return (
-        <Space align="center">
-            <div style={{ display: "grid" }}>
+        <Flex justify="center" align="center" gap={6} style={{ width: "max-content", minWidth: "100%" }}>
+            <div style={{ display: "grid", flex: "0 0 auto" }}>
                 {/* These invisible spans are layered on top of each other in the same grid
                 space which auto-sizes the parent to the width of the largest item.
                 The Select - taking up 100% of the parent - will then get the width of
@@ -31,6 +33,8 @@ const HeaderBody = () => {
                     <span key={v} style={{
                         gridArea: "1/1",
                         visibility: "hidden",
+                        whiteSpace: "nowrap",
+                        lineHeight: 0,
                         paddingRight: "42px" // Safety padding for the caret
                     }}>{v}</span>
                 ))}
@@ -53,10 +57,16 @@ const HeaderBody = () => {
                     ))}
                 </Select>
             </div>
-            <JarDecompilerModalButton />
-            <SettingsModalButton />
-            <AboutModalButton />
-        </Space>
+            <div style={{ flex: "0 0 auto" }}>
+                <JarDecompilerModalButton />
+            </div>
+            <div style={{ flex: "0 0 auto" }}>
+                <SettingsModalButton />
+            </div>
+            <div style={{ flex: "0 0 auto" }}>
+                <AboutModalButton />
+            </div>
+        </Flex>
     );
 };
 


### PR DESCRIPTION
# Explanation
The sidebar header had some issues when narrowing it down. It would make the buttons a little taller for some reason at a certain threshold, and going narrower would cause the dropdown to go out of sight while introducing 2 different scrollbars at the bottom of the sidebar.

This PR fixes that with some html/css changes. Now, the sidebar header horizontal scrollbar is separate from the sidebar scrollbar, and it no longer grows taller/goes out sight when getting too narrow.

# Demonstration

## Current:
https://github.com/user-attachments/assets/e553623a-a269-4435-92cc-c7a7b6c46753
## This PR:
https://github.com/user-attachments/assets/6874c601-de8f-4a6b-889a-a9153dae6d6b

