### PR TITLE
Fix code editor scroll persistence

### DIFF
--- a/src/logic/tabs/InheritanceViewTab.ts
+++ b/src/logic/tabs/InheritanceViewTab.ts
@@ -7,6 +7,7 @@ export class InheritanceViewTab extends Tab {
     public innerTabs: {
         active: string,
         tree: {
+            scrollTop: number,
             initialized: boolean,
             nodes: TreeDataNode[],
             expanded: Key[];
@@ -20,6 +21,7 @@ export class InheritanceViewTab extends Tab {
     } = {
             active: "tree",
             tree: {
+                scrollTop: 0,
                 initialized: false,
                 nodes: [],
                 expanded: []

--- a/src/logic/tabs/Tabs.ts
+++ b/src/logic/tabs/Tabs.ts
@@ -4,7 +4,6 @@ import { CodeTab, InheritanceViewTab } from "./index";
 
 export abstract class Tab {
     public key: string;
-    public scroll: number = 0;
 
     public constructor(key: string) {
         this.key = key;

--- a/src/ui/Code.tsx
+++ b/src/ui/Code.tsx
@@ -174,13 +174,6 @@ const Code = () => {
     useEffect(() => {
         if (editorRef.current && decompileResult) {
             const editor = editorRef.current;
-            // const currentTab = openTabs.value.find(tab => tab.key === selectedFile.value);
-            const currentTab = getOpenTab();
-            const prevTab = openTabs.value.find(tab => tab.key === tabHistory.value.at(-2));
-            if (prevTab) {
-                prevTab.scroll = editor.getScrollTop();
-            }
-
             lineHighlightRef.current?.clear();
 
             const executeScroll = () => {
@@ -199,10 +192,6 @@ const Code = () => {
                             glyphMarginClassName: 'highlighted-line-glyph'
                         }
                     }]);
-                } else if (currentTab && currentTab.scroll > 0) {
-                    editor.setScrollTop(currentTab.scroll);
-                } else {
-                    editor.setScrollTop(0);
                 }
             };
 

--- a/src/ui/inheritance/InheritanceTree.tsx
+++ b/src/ui/inheritance/InheritanceTree.tsx
@@ -1,5 +1,5 @@
 import { Tree, type TreeDataNode } from "antd";
-import { useCallback, type Key } from "react";
+import { useCallback, useEffect, useRef, type Key } from "react";
 import { ClassNode } from "../../logic/Inheritance";
 import { InheritanceViewTab, openCodeTab } from "../../logic/tabs";
 import { ClassDataIcon } from "../intellij-icons";
@@ -97,31 +97,45 @@ const InheritanceTree = ({ tab, data }: { tab: InheritanceViewTab, data: ClassNo
         openCodeTab(`${selected}.class`);
     }, []);
 
+    const scrollRef = useRef<HTMLDivElement>(null);
+    useEffect(() => {
+        if (!scrollRef.current) return;
+        if (tab.innerTabs.active !== "tree") return;
+        scrollRef.current.scrollTop = tab.innerTabs.tree.scrollTop;
+    }, []);
+
     return (
-        <Tree
-            styles={{
-                root: {
-                    background: "transparent",
-                    height: "100%",
-                    overflow: "auto",
-                    paddingBottom: "3rem"
-                },
-                itemIcon: {
-                    position: "relative",
-                    display: "flex",
-                    justifyContent: "center",
-                    alignItems: "center"
-                }
+        <div
+            ref={scrollRef}
+            style={{ height: "100%", overflow: "auto" }}
+            onScroll={(e) => {
+                if (tab.innerTabs.active !== "tree") return;
+                tab.innerTabs.tree.scrollTop = e.currentTarget.scrollTop;
             }}
-            key={data?.name ?? "inheritance-tree"}
-            treeData={nodes}
-            selectedKeys={data ? [data.name] : []}
-            defaultExpandedKeys={expanded}
-            onExpand={(expanded) => tab.innerTabs.tree.expanded = expanded}
-            showLine
-            showIcon
-            onSelect={onSelect}
-        />
+        >
+            <Tree
+                styles={{
+                    root: {
+                        background: "transparent",
+                        marginBottom: "3rem"
+                    },
+                    itemIcon: {
+                        position: "relative",
+                        display: "flex",
+                        justifyContent: "center",
+                        alignItems: "center"
+                    }
+                }}
+                key={data?.name ?? "inheritance-tree"}
+                treeData={nodes}
+                selectedKeys={data ? [data.name] : []}
+                defaultExpandedKeys={expanded}
+                onExpand={(expanded) => tab.innerTabs.tree.expanded = expanded}
+                showLine
+                showIcon
+                onSelect={onSelect}
+            />
+        </div>
     );
 };
 

--- a/src/ui/inheritance/InheritanceTree.tsx
+++ b/src/ui/inheritance/InheritanceTree.tsx
@@ -102,6 +102,7 @@ const InheritanceTree = ({ tab, data }: { tab: InheritanceViewTab, data: ClassNo
         if (!scrollRef.current) return;
         if (tab.innerTabs.active !== "tree") return;
         scrollRef.current.scrollTop = tab.innerTabs.tree.scrollTop;
+        // oxlint-disable-next-line eslint-plugin-react-hooks/exhaustive-deps
     }, []);
 
     return (


### PR DESCRIPTION
- Fixes the issue described [here](https://discord.com/channels/507304429255393322/1459132346577064017/1498363985802821652), where `Code.tsx` would not properly scroll to the correct position because it couldn't save one due to the tab changes
  - I removed that code because the scroll position is persisted through the viewstate already
-  I also made the scroll position persist for the hierarchy tree view as that wasn't the case before and something I missed previously