### PR TITLE
Add support for versions with official deobfuscation mappings

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -9,8 +9,11 @@ repositories {
 
 dependencies {
     api libs.asm
+    api libs.asm.commons
     api libs.asm.util
     api libs.teavm.core
+    api libs.mapping.io
+    api libs.mapping.io.extras
     testImplementation libs.teavm.jso
 }
 

--- a/java/gradle/libs.versions.toml
+++ b/java/gradle/libs.versions.toml
@@ -1,10 +1,14 @@
 [versions]
 asm = "9.9.1"
 teavm = "0.13.0"
+mapping-io = "0.8.0"
 
 [libraries]
 asm = { module = "org.ow2.asm:asm", version.ref = "asm" }
+asm-commons = { module = "org.ow2.asm:asm-commons", version.ref = "asm" }
 asm-util = { module = "org.ow2.asm:asm-util", version.ref = "asm" }
+mapping-io = { module = "net.fabricmc:mapping-io", version.ref = "mapping-io" }
+mapping-io-extras = { module = "net.fabricmc:mapping-io-extras", version.ref = "mapping-io" }
 teavm-core = { group = "org.teavm", name = "teavm-core", version.ref = "teavm" }
 teavm-jso = { group = "org.teavm", name = "teavm-jso-apis", version.ref = "teavm" }
 

--- a/java/src/main/java/mcsrc/Indexer.java
+++ b/java/src/main/java/mcsrc/Indexer.java
@@ -1,15 +1,27 @@
 package mcsrc;
 
+import net.fabricmc.mappingio.MappingUtil;
+import net.fabricmc.mappingio.extras.MappingTreeRemapper;
+import net.fabricmc.mappingio.format.proguard.ProGuardFileReader;
+import net.fabricmc.mappingio.tree.MemoryMappingTree;
 import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.commons.ClassRemapper;
 import org.objectweb.asm.util.Textifier;
 import org.objectweb.asm.util.TraceClassVisitor;
 import org.teavm.jso.JSExport;
+import org.teavm.jso.core.JSMap;
+import org.teavm.jso.core.JSString;
 import org.teavm.jso.typedarrays.ArrayBuffer;
 import org.teavm.jso.typedarrays.Int8Array;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 public class Indexer {
@@ -17,6 +29,9 @@ public class Indexer {
     private static int referenceSize = 0;
     
     private static final Map<String, ClassInheritanceInfo> inheritanceData = new HashMap<>();
+
+    private static MemoryMappingTree mappingTree;
+    private static MappingTreeRemapper mappingTreeRemapper;
 
     @JSExport
     public static void index(ArrayBuffer arrayBuffer) {
@@ -89,6 +104,53 @@ public class Indexer {
             result.add(sb.toString());
         }
         return result.toArray(new String[0]);
+    }
+
+    @JSExport
+    public static void loadMappings(ArrayBuffer mappings) {
+        var mappingsArray = new Int8Array(mappings).copyToJavaArray();
+        var mappingsReader = new InputStreamReader(new ByteArrayInputStream(mappingsArray), StandardCharsets.UTF_8);
+        try {
+            var tree = new MemoryMappingTree();
+            ProGuardFileReader.read(mappingsReader, tree);
+            mappingTree = tree;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        mappingTreeRemapper = new MappingTreeRemapper(mappingTree, MappingUtil.NS_TARGET_FALLBACK, MappingUtil.NS_SOURCE_FALLBACK);
+    }
+
+    @JSExport
+    public static JSMap<JSString, JSString> getObfToDeobf() {
+        int obfId = mappingTree.getNamespaceId(MappingUtil.NS_TARGET_FALLBACK);
+        int deobfId = mappingTree.getNamespaceId(MappingUtil.NS_SOURCE_FALLBACK);
+        var map = new JSMap<JSString, JSString>();
+        for (var mapping : mappingTree.getClasses()) {
+            String obfName = mapping.getName(obfId);
+            String deobfName = mapping.getName(deobfId);
+            map.set(JSString.valueOf(obfName), JSString.valueOf(deobfName));
+        }
+        return map;
+    }
+
+    @JSExport
+    public static Int8Array remapEntry(ArrayBuffer entry) {
+        var classBytes = new Int8Array(entry).copyToJavaArray();
+        ClassReader reader = new ClassReader(classBytes);
+        // Use a ClassWriter subclass that overrides getCommonSuperClass to avoid
+        // TypeNotPresentException which is not available in TeaVM's JRE emulation.
+        // Since we pass 0 (no COMPUTE_FRAMES), getCommonSuperClass is never called at runtime.
+        ClassWriter writer = new ClassWriter(0) {
+            @Override
+            protected String getCommonSuperClass(String type1, String type2) {
+                return "java/lang/Object";
+            }
+        };
+        reader.accept(new ClassRemapper(writer, mappingTreeRemapper), 0);
+        var remappedBytes = writer.toByteArray();
+        var array = new Int8Array(remappedBytes.length);
+        array.set(remappedBytes);
+        return array;
     }
     
     private static class ClassInheritanceInfo {

--- a/src/logic/MinecraftApi.ts
+++ b/src/logic/MinecraftApi.ts
@@ -33,6 +33,7 @@ export interface MinecraftJar {
     version: string;
     jar: Jar;
     blob: Blob;
+    mappingsBlob: Blob | null;
 }
 
 export const minecraftVersions = agreedEula.observable.pipe(
@@ -88,14 +89,35 @@ async function getJson<T>(url: string): Promise<T> {
     return response.json();
 }
 
+const RELEASE_PATTERN = /^1\.\d+(\.\d+)?$/;
+const SNAPSHOT_PATTERN = /^\d{2}w\d{2}[a-z]$/;
+
 async function fetchVersions(): Promise<VersionsList> {
     const mojang = await getJson<VersionsList>(VERSIONS_URL);
     const filteredMojangVersions = mojang.versions.filter(v => {
+        // Any version released after 2026 is deobfuscated
         if (new Date(v.releaseTime).getFullYear() >= 2026) return true;
-        const match = v.id.match(/^(\d+)\.(\d+)/);
-        if (!match) return false;
-        const major = parseInt(match[1], 10);
-        return major >= 26;
+
+        // Release 1.14.4 and newer have official deobfuscation mappings
+        if (v.type === "release" && RELEASE_PATTERN.test(v.id)) {
+            const m = v.id.match(/^1\.(\d+)(?:\.(\d+))?$/);
+            if (m) {
+                const minor = parseInt(m[1], 10);
+                const patch = m[2] ? parseInt(m[2], 10) : 0;
+                if (minor > 14 || (minor === 14 && patch >= 4)) return true;
+            }
+        }
+        // Snapshot 19w36a and newer have official deobfuscation mappings
+        if (v.type === "snapshot" && SNAPSHOT_PATTERN.test(v.id)) {
+            const m = v.id.match(/^(\d{2})w(\d{2})[a-z]$/);
+            if (m) {
+                const year = parseInt(m[1], 10) + 2000;
+                const week = parseInt(m[2], 10);
+                if (year > 2019 || (year === 2019 && week >= 36)) return true;
+            }
+        }
+
+        return false;
     });
     const versions = filteredMojangVersions
         .concat(EXPERIMENTAL_VERSIONS.versions)
@@ -174,14 +196,18 @@ async function downloadMinecraftJar(version: VersionListEntry, progress: Behavio
     console.log(`Downloading Minecraft jar for version: ${version.id}`);
     const versionManifest = await fetchVersionManifest(version);
     const clientUrl = versionManifest.downloads.client.url;
+    const clientMappingsUrl = versionManifest.downloads.client_mappings?.url;
 
-    const blob = await cachedFetch(clientUrl, (percent) => {
-        progress.next(percent);
-    });
+    let [mappingsBlob, blob] = await Promise.all([
+        clientMappingsUrl ? cachedFetch(clientMappingsUrl) : Promise.resolve(null),
+        cachedFetch(clientUrl, (percent) => {
+            progress.next(percent);
+        })
+    ]);
 
-    const jar = await openJar(version.id, blob);
+    const jar = await openJar(version.id, blob, mappingsBlob);
     progress.next(undefined);
-    return { version: version.id, jar, blob };
+    return { version: version.id, jar, blob, mappingsBlob };
 }
 
 // Hardcode as these are never going to change.

--- a/src/utils/Jar.ts
+++ b/src/utils/Jar.ts
@@ -1,16 +1,29 @@
 import { read, type Entry, type Reader, type Zip, readBlob } from "@katana-project/zip";
+import { createRemappedJarView } from "../workers/remap/jar";
+
+export interface JarEntry {
+    bytes(): Promise<Uint8Array>;
+    name: string;
+    crc32: number;
+    uncompressedSize: number;
+};
 
 export interface Jar {
     name: string;
     blob: Blob;
-    entries: { [key: string]: Entry; };
+    mappingsBlob: Blob | null;
+    entries: { [key: string]: JarEntry; };
 }
 
-export async function openJar(name: string, blob: Blob): Promise<Jar> {
+export async function openJar(name: string, blob: Blob, mappingsBlob: Blob | null): Promise<Jar> {
     const zip = await readBlob(blob, {
         naive: true
     });
-    return new JarImpl(name, blob, zip);
+    if (mappingsBlob) {
+        return createRemappedJarView(name, blob, mappingsBlob, zip);
+    } else {
+        return new JarImpl(name, blob, zip);
+    }
 }
 
 // TODO: fix
@@ -26,12 +39,14 @@ class JarImpl implements Jar {
     private zip: Zip;
     public name: string;
     public blob: Blob;
+    public mappingsBlob: null;
     public entries: { [key: string]: Entry; } = {};
 
     constructor(name: string, blob: Blob, zip: Zip) {
         this.name = name;
         this.blob = blob;
         this.zip = zip;
+        this.mappingsBlob = null;
         zip.entries.forEach(entry => {
             this.entries[entry.name] = entry;
         });

--- a/src/workers/decompile/client.ts
+++ b/src/workers/decompile/client.ts
@@ -95,7 +95,7 @@ export function decompileEntireJar(jar: Jar, options?: DecompileEntireJarOptions
                 await ensureWorkers(optThreads);
                 const result = await Promise.all((workers
                     .slice(0, optThreads))
-                    .map(w => w.decompileMany(jar.name, jar.blob, classNames, sab, optSplits, optLogger)));
+                    .map(w => w.decompileMany(jar.name, jar.blob, jar.mappingsBlob, classNames, sab, optSplits, optLogger)));
                 const total = result.reduce((acc, n) => acc + n, 0);
                 return total;
             } finally {
@@ -122,7 +122,7 @@ export async function decompileClass(className: string, jar: Jar): Promise<Decom
     };
 
     const worker = await findWorker();
-    return await worker.decompile(className, jar.name, jar.blob);
+    return await worker.decompile(className, jar.name, jar.blob, jar.mappingsBlob);
 }
 
 export async function getClassBytecode(className: string, jar: Jar): Promise<DecompileResult> {

--- a/src/workers/decompile/worker.ts
+++ b/src/workers/decompile/worker.ts
@@ -86,13 +86,14 @@ export class DecompileWorker {
     decompileMany = (
         jarName: string,
         jarBlob: Blob,
+        mappingsBlob: Blob | null,
         classNames: string[],
         sab: SharedArrayBuffer,
         splits: number,
         logger?: (index: number) => Promise<void> | void,
     ): Promise<number> => this.schedule(async () => {
         const state = new Uint32Array(sab);
-        const jar = new DecompileJar(await openJar(jarName, jarBlob));
+        const jar = new DecompileJar(await openJar(jarName, jarBlob, mappingsBlob));
 
         let logPromises: Promise<void>[] = [];
         let nameLogger;
@@ -148,9 +149,10 @@ export class DecompileWorker {
         className: string,
         jarName: string,
         jarBlob: Blob,
+        mappingsBlob: Blob | null
     ): Promise<DecompileResult> => this.schedule(async () => {
         try {
-            const jar = new DecompileJar(await openJar(jarName, jarBlob));
+            const jar = new DecompileJar(await openJar(jarName, jarBlob, mappingsBlob));
             const checksum = jar.proxy[className]?.checksum;
             const dbResult = await this.db.results3.get([className, checksum, "java"]);
             if (dbResult) return dbResult;

--- a/src/workers/jar-index/client.ts
+++ b/src/workers/jar-index/client.ts
@@ -102,7 +102,7 @@ export class JarIndex {
             console.log(`Indexing minecraft jar using ${this.workers.length} workers`);
 
             // Initialize all workers in parallel
-            await Promise.all(this.workers.map(worker => worker.c.setJar(this.minecraftJar.version, this.minecraftJar.blob)));
+            await Promise.all(this.workers.map(worker => worker.c.setJar(this.minecraftJar.version, this.minecraftJar.blob, this.minecraftJar.mappingsBlob)));
 
             const jar = this.minecraftJar.jar;
             const classNames = Object.keys(jar.entries)
@@ -145,7 +145,7 @@ export class JarIndex {
             this.indexPromise = null;
             throw error;
         } finally {
-            await Promise.all(this.workers.map(worker => worker.c.setJar("", null)));
+            await Promise.all(this.workers.map(worker => worker.c.setJar("", null, null)));
         }
     }
 

--- a/src/workers/jar-index/types.ts
+++ b/src/workers/jar-index/types.ts
@@ -33,13 +33,30 @@ export class JarIndexer {
         return this.#indexerFunc;
     };
 
-    setJar = async (name: string, blob: Blob | null) => {
+    setJar = async (name: string, blob: Blob | null, mappingsBlob: Blob | null) => {
         if (!blob) {
             this.#jar = null;
             return;
         }
 
-        this.#jar = await openJar(name, blob);
+        this.#jar = await openJar(name, blob, mappingsBlob);
+    };
+
+    getObfToDeobf = async () => {
+        const indexer = await this.getIndexer();
+        return indexer.getObfToDeobf();
+    };
+
+    loadMappings = async (mappingsBlob: Blob) => {
+        const indexer = await this.getIndexer();
+        const mappingsBuffer = await mappingsBlob.arrayBuffer();
+        indexer.loadMappings(mappingsBuffer);
+    };
+
+    remapEntry = async (classBlob: Blob) => {
+        const indexer = await this.getIndexer();
+        const classBuffer = await classBlob.arrayBuffer();
+        return new Blob([indexer.remapEntry(classBuffer)]);
     };
 
     indexBatch = async (classNames: string[]): Promise<void> => {
@@ -50,8 +67,8 @@ export class JarIndexer {
         const currentJar = this.#jar; // Capture for closure
         const arrayBufferPromises = classNames.map(async className => {
             const entry = currentJar.entries[className];
-            const data = await entry.blob();
-            return data.arrayBuffer();
+            const data = await entry.bytes();
+            return data.buffer;
         });
 
         const indexer = await this.getIndexer();
@@ -84,6 +101,9 @@ export class JarIndexer {
 
 interface Indexer {
     index(data: ArrayBufferLike): void;
+    loadMappings(data: ArrayBufferLike): void;
+    remapEntry(classData: ArrayBufferLike): Int8Array<ArrayBuffer>;
+    getObfToDeobf(): Map<string, string>;
     getReference(key: ReferenceKey): [ReferenceString];
     getReferenceSize(): number;
     getBytecode(classData: ArrayBufferLike[]): string;

--- a/src/workers/remap/jar.ts
+++ b/src/workers/remap/jar.ts
@@ -1,0 +1,65 @@
+import * as Comlink from "comlink";
+
+import type { Entry, Zip } from "@katana-project/zip";
+import type { Jar, JarEntry } from "../../utils/Jar";
+
+import type { JarIndexer } from "../jar-index/types";
+
+export async function createRemappedJarView(name: string, blob: Blob, mappingsBlob: Blob, zip: Zip): Promise<Jar> {
+    const worker = createWrorker().c;
+    const entries: { [key: string]: JarEntry; } = {};
+    await worker.loadMappings(mappingsBlob);
+    const obfToDeobfMap = await worker.getObfToDeobf();
+
+    zip.entries.forEach(entry => {
+        if (entry.name.endsWith(".class")) {
+            const classPath = entry.name.replace(/\.class$/, "");
+            let deobfName = obfToDeobfMap.get(classPath);
+            if (!deobfName) {
+                console.warn("Cannot remap class " + classPath);
+                entries[entry.name] = entry;
+            } else {
+                entries[deobfName + ".class"] = createRemappedEntry(worker, entry);
+            }
+        } else {
+            entries[entry.name] = entry;
+        }
+    });
+
+    return {
+        name: name,
+        blob: blob,
+        mappingsBlob: mappingsBlob,
+        entries: entries
+    };
+}
+
+function createRemappedEntry(worker: Comlink.Remote<JarIndexer>, entry: Entry): JarEntry {
+    return {
+        name: entry.name,
+        // TODO: these are technically wrong since they are from the unremapped entry
+        crc32: entry.crc32,
+        uncompressedSize: entry.uncompressedSize,
+        bytes: (() => {
+            // TODO: how will this scale if a worker tries to decompile the whole jar?
+            let cachedPromise: Promise<Uint8Array<ArrayBuffer>> | undefined;
+            return async (): Promise<Uint8Array<ArrayBuffer>> => {
+                if (!cachedPromise) {
+                    cachedPromise = entry.bytes().then(async (obfBytes) => {
+                        const remappedBlob = await worker.remapEntry(new Blob([obfBytes as Uint8Array<ArrayBuffer>]));
+                        return remappedBlob.bytes();
+                    });
+                }
+                return cachedPromise;
+            };
+        })()
+    };
+}
+
+function createWrorker() {
+    const worker = new Worker(new URL("./worker.ts", import.meta.url), { type: "module", name: "jar-remapper" });
+    return {
+        c: Comlink.wrap<JarIndexer>(worker),
+        w: worker,
+    };
+}

--- a/src/workers/remap/worker.ts
+++ b/src/workers/remap/worker.ts
@@ -1,0 +1,4 @@
+import * as Comlink from "comlink";
+import { JarIndexer } from "../jar-index/types";
+
+Comlink.expose(new JarIndexer());


### PR DESCRIPTION
This PR extends the range of supported versions back to 1.14.4 by adding the ability to remap the game jar using Mojang's ProGuard mappings from the version manifest.

It will stay in draft state until I figure out a solution to indexing performance. Currently, indexing 1.16.5 takes about 2 minutes on a Ryzen 7700X, which is pretty ridiculous. Decompilation seems fine since only classes the user clicks on need processing.

The most notable design decision is that remapping is handled at the `Jar` interface level, by exposing fake entries with the deobfuscated names. Remapping the bytecode is done lazily the first time `bytes` is invoked on an entry. This avoids needing to remap the entire jar in one shot, which takes way too long to be usable, at least if done on one thread.