### PR TITLE
Add auto jar index setting

### DIFF
--- a/src/logic/Settings.ts
+++ b/src/logic/Settings.ts
@@ -141,6 +141,7 @@ export const theme = new StringSetting<ThemeMode>('theme', 'system', ['light', '
 export const agreedEula = new BooleanSetting('eula', false);
 export const enableTabs = new BooleanSetting('enable_tabs', true);
 export const compactPackages = new BooleanSetting('compact_packages', true);
+export const autoJarIndex = new BooleanSetting('auto_jar_index', true);
 export const displayLambdas = new BooleanSetting('display_lambdas', false);
 export const bytecode = new BooleanSetting('bytecode', false);
 export const unifiedDiff = new BooleanSetting('unified_diff', false);

--- a/src/ui/FileList.tsx
+++ b/src/ui/FileList.tsx
@@ -2,7 +2,7 @@
 import { Tree, Dropdown, message } from 'antd';
 import type { TreeDataNode, TreeProps, MenuProps } from 'antd';
 import { CaretDownFilled } from '@ant-design/icons';
-import { combineLatest, from, map, Observable, shareReplay, switchMap, startWith } from 'rxjs';
+import { combineLatest, from, map, Observable, of, shareReplay, switchMap, startWith } from 'rxjs';
 import { classesList } from '../logic/JarFile';
 import { useObservable } from '../utils/UseObservable';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -11,12 +11,15 @@ import { openCodeTab } from '../logic/tabs';
 import { minecraftJar, type MinecraftJar } from '../logic/MinecraftApi';
 import { decompileClass } from '../logic/Decompiler';
 import { selectedFile, referencesQuery } from '../logic/State';
-import { compactPackages } from '../logic/Settings';
+import { autoJarIndex, compactPackages } from '../logic/Settings';
 import { jarIndex, type ClassData } from '../workers/jar-index/client';
 import { ClassDataIcon, JavaIcon, PackageIcon } from './intellij-icons';
 
-const classData: Observable<Map<string, ClassData> | null> = jarIndex.pipe(
-    switchMap(jarIndex => from(jarIndex.getClassData()).pipe(
+const classData: Observable<Map<string, ClassData> | null> = combineLatest([
+    jarIndex,
+    autoJarIndex.observable
+]).pipe(
+    switchMap(([jarIndex, enabled]) => enabled ? from(jarIndex.getClassData()).pipe(
         map(classes => {
             const map = new Map<string, ClassData>();
             for (const data of classes) {
@@ -25,7 +28,7 @@ const classData: Observable<Map<string, ClassData> | null> = jarIndex.pipe(
             return map;
         }),
         startWith(null)
-    )),
+    ) : of(null)),
     shareReplay(1)
 );
 

--- a/src/ui/SettingsModal.tsx
+++ b/src/ui/SettingsModal.tsx
@@ -2,7 +2,7 @@ import { Button, Modal, type CheckboxProps, Form, Tooltip, InputNumber, type Inp
 import { SettingOutlined, SunOutlined, MoonOutlined, DesktopOutlined } from '@ant-design/icons';
 import { Checkbox } from 'antd';
 import { useObservable } from "../utils/UseObservable";
-import { BooleanSetting, enableTabs, displayLambdas, focusSearch, KeybindSetting, type KeybindValue, bytecode, showStructure, NumberSetting, preferWasmDecompiler, compactPackages, theme } from "../logic/Settings";
+import { BooleanSetting, enableTabs, displayLambdas, focusSearch, KeybindSetting, type KeybindValue, bytecode, showStructure, NumberSetting, preferWasmDecompiler, compactPackages, theme, autoJarIndex } from "../logic/Settings";
 import { capturingKeybind, rawKeydownEvent } from "../logic/Keybinds";
 import { BehaviorSubject } from "rxjs";
 import type React from "react";
@@ -33,6 +33,7 @@ const SettingsModal = () => {
                 <ThemeOption />
                 <BooleanOption setting={enableTabs} title={"Enable Tabs"} />
                 <BooleanOption setting={compactPackages} title={"Compact Packages"} tooltip="Collapse packages with one child into one." />
+                <BooleanOption setting={autoJarIndex} title={"Auto Jar Index"} tooltip="Automatically index class metadata for file icons." />
                 <BooleanOption setting={displayLambdas} title={"Lambda Names"} tooltip="Display lambda names as inline comments. Does not support permalinking." disabled={bytecodeValue} />
                 <BooleanOption setting={bytecode} title={"Show Bytecode"} tooltip="Show bytecode instructions alongside decompiled source. Does not support permalinking." disabled={displayLambdasValue} />
                 <BooleanOption setting={preferWasmDecompiler} title={"Prefer WASM Decompiler"} tooltip="WASM decompiler might be faster than JavaScript."/>

--- a/src/workers/jar-index/client.ts
+++ b/src/workers/jar-index/client.ts
@@ -63,7 +63,7 @@ export class JarIndex {
     private _workers: ReturnType<typeof createWrorker>[] | undefined;
     private get workers() {
         if (this._workers) return this._workers;
-        const threads = navigator.hardwareConcurrency || 4;
+        const threads = Math.max(1, (navigator.hardwareConcurrency || 4) - 1);
         this._workers = Array.from({ length: threads }, () => createWrorker());
         console.log(`Created JarIndex with ${threads} workers`);
         return this._workers;


### PR DESCRIPTION
This may help on some mobile devices, in the future we might want to default this to false for mobile devices.

Also reduced the threads used by the jar index by 1 so the decompile worker has somewhere to go.