### PR TITLE
Add dedicated TS types for each string class type.

### DIFF
--- a/src/javadoc/Javadoc.ts
+++ b/src/javadoc/Javadoc.ts
@@ -2,15 +2,16 @@ import { BehaviorSubject, map, Observable } from "rxjs";
 import type { Token } from "../logic/Tokens";
 import { javadocApi } from "./api/JavadocApi";
 import { selectedMinecraftVersion } from "../logic/State";
+import { toClassName, type ClassName } from "../utils/Names";
 
 export type JavadocString = string;
 
 export interface JavadocData {
-    classes: Record<string, {
+    classes: Partial<Record<ClassName, {
         javadoc: JavadocString | null;
         methods: Record<string, JavadocString>;
         fields: Record<string, JavadocString>;
-    }>;
+    }>>;
 }
 
 export const javadocData = new BehaviorSubject<JavadocData>({
@@ -46,7 +47,7 @@ export function setTokenJavadoc(token: Token, javadoc: JavadocString | undefined
 }
 
 // Refreshes the Javadoc data for a specific class from the server
-export async function refreshJavadocDataForClass(className: string) {
+export async function refreshJavadocDataForClass(className: ClassName) {
     const minecraftVersion = selectedMinecraftVersion.value;
     if (!minecraftVersion) {
         throw new Error("No Minecraft version selected");
@@ -55,12 +56,13 @@ export async function refreshJavadocDataForClass(className: string) {
     const data = await javadocApi.getJavadoc(minecraftVersion, className);
 
     for (const [key, entry] of Object.entries(data.data)) {
-        const classEntry = javadocData.getValue().classes[key] || { javadoc: null, methods: {}, fields: {} };
+        const className = toClassName(key);
+        const classEntry = javadocData.getValue().classes[className] || { javadoc: null, methods: {}, fields: {} };
         classEntry.javadoc = entry.value || null;
         classEntry.methods = entry.methods || {};
         classEntry.fields = entry.fields || {};
         const nextData = { ...javadocData.getValue() };
-        nextData.classes[key] = classEntry;
+        nextData.classes[className] = classEntry;
         javadocData.next(nextData);
     }
 }

--- a/src/javadoc/JavadocCmpletionProvider.ts
+++ b/src/javadoc/JavadocCmpletionProvider.ts
@@ -1,6 +1,7 @@
 import { editor, languages, Position, Token, type CancellationToken } from 'monaco-editor';
 import type { MemberToken } from '../logic/Tokens';
 import type { DecompileResult } from '../workers/decompile/types';
+import { simpleDottedClassName, toDottedClassName, type DottedClassName } from '../utils/Names';
 
 export class JavdocCompletionProvider implements languages.CompletionItemProvider {
     readonly decompileResult: DecompileResult;
@@ -39,7 +40,7 @@ export class JavdocCompletionProvider implements languages.CompletionItemProvide
         const imports = this.getImportedClasses();
 
         const suggestions: languages.CompletionItem[] = imports.map(importPath => {
-            const className = importPath.split('.').pop() || importPath;
+            const className = simpleDottedClassName(importPath);
 
             return {
                 label: className,
@@ -74,9 +75,9 @@ export class JavdocCompletionProvider implements languages.CompletionItemProvide
         return textAfterBracket.startsWith('#');
     }
 
-    getImportedClasses(): string[] {
+    getImportedClasses(): DottedClassName[] {
         const source = this.decompileResult.source;
-        const importedClasses: string[] = [];
+        const importedClasses: DottedClassName[] = [];
 
         const importRegex = /^\s*import\s+(?!static\b)([^\s;]+)\s*;/gm;
 
@@ -87,7 +88,7 @@ export class JavdocCompletionProvider implements languages.CompletionItemProvide
                 continue;
             }
 
-            importedClasses.push(importPath);
+            importedClasses.push(toDottedClassName(importPath));
         }
 
         return importedClasses;

--- a/src/javadoc/JavadocCodeExtensions.ts
+++ b/src/javadoc/JavadocCodeExtensions.ts
@@ -85,7 +85,7 @@ export function applyJavadocCodeExtensions(monaco: monaco, editor: editor.IStand
         }
     });
 
-    refreshJavadocDataForClass(decompile.className.replace(".class", "")).catch(err => {
+    refreshJavadocDataForClass(decompile.className).catch(err => {
         console.error("Failed to refresh Javadoc data for class:", err);
     });
 

--- a/src/javadoc/api/JavadocApi.ts
+++ b/src/javadoc/api/JavadocApi.ts
@@ -1,5 +1,6 @@
 import { BehaviorSubject, map } from "rxjs";
 import { IS_JAVADOC_EDITOR } from "../../site";
+import type { ClassName } from "../../utils/Names";
 
 class JavadocApi {
     // The current access token, or null if not authenticated
@@ -31,7 +32,7 @@ class JavadocApi {
         return response.status == 200;
     }
 
-    async getJavadoc(version: string, className: string): Promise<JavadocResponse> {
+    async getJavadoc(version: string, className: ClassName): Promise<JavadocResponse> {
         const requestBody = {
             className
         };
@@ -127,7 +128,7 @@ export interface JavadocEntry {
 }
 
 export interface UpdateJavadocRequest {
-    className: string;
+    className: ClassName;
     target: UpdateTarget | null;
     documentation: string;
 }

--- a/src/logic/Decompiler.ts
+++ b/src/logic/Decompiler.ts
@@ -10,6 +10,7 @@ import type { Options } from "./vf";
 import type { DecompileResult } from "../workers/decompile/types";
 import * as worker from "../workers/decompile/client";
 import type { Jar } from "../utils/Jar";
+import { classNameFromClassFilePath, type ClassName } from "../utils/Names";
 
 const decompilerCounter = new BehaviorSubject<number>(0);
 
@@ -44,11 +45,12 @@ export function decompileResultPipeline(jar: Observable<MinecraftJar>): Observab
     ]).pipe(
         distinctUntilChanged(),
         throttleTime(250),
-        switchMap(([className, jar, bytecode]) => {
-            if (!className) {
+        switchMap(([file, jar, bytecode]) => {
+            if (!file) {
                 return of();
             }
 
+            const className = classNameFromClassFilePath(file);
             if (bytecode) {
                 return from(getClassBytecode(className, jar.jar));
             }
@@ -59,7 +61,7 @@ export function decompileResultPipeline(jar: Observable<MinecraftJar>): Observab
     );
 }
 
-export async function getClassBytecode(className: string, jar: Jar) {
+export async function getClassBytecode(className: ClassName, jar: Jar) {
     try {
         decompilerCounter.next(decompilerCounter.value + 1);
         return await worker.getClassBytecode(className, jar);
@@ -68,7 +70,7 @@ export async function getClassBytecode(className: string, jar: Jar) {
     }
 }
 
-export async function decompileClass(className: string, jar: Jar) {
+export async function decompileClass(className: ClassName, jar: Jar) {
     try {
         decompilerCounter.next(decompilerCounter.value + 1);
         return await worker.decompileClass(className, jar);

--- a/src/logic/Diff.ts
+++ b/src/logic/Diff.ts
@@ -4,15 +4,16 @@ import { currentResult, decompileResultPipeline } from "./Decompiler";
 import { calculatedLineChanges } from "./LineChanges";
 import { diffLeftSelectedMinecraftVersion, selectedMinecraftVersion } from "./State";
 import type { DecompileResult } from "../workers/decompile/types";
+import { classNameFromClassFilePath, isClassFilePath, toClassFilePath, withoutClassExtension, type ClassFilePath, type ClassName } from "../utils/Names";
 
 export interface EntryInfo {
-    classCrcs: Map<string, number>;
+    classCrcs: Map<ClassName, number>;
 }
 
 export interface DiffSide {
     selectedVersion: BehaviorSubject<string | null>;
     jar: Observable<MinecraftJar>;
-    entries: Observable<Map<string, EntryInfo>>;
+    entries: Observable<Map<ClassFilePath, EntryInfo>>;
     result: Observable<DecompileResult>;
 }
 
@@ -69,8 +70,8 @@ setTimeout(() => {
     });
 }, 0);
 
-let diffChanges: Observable<Map<string, ChangeInfo>> | null = null;
-export function getDiffChanges(): Observable<Map<string, ChangeInfo>> {
+let diffChanges: Observable<Map<ClassFilePath, ChangeInfo>> | null = null;
+export function getDiffChanges(): Observable<Map<ClassFilePath, ChangeInfo>> {
     if (!diffChanges) {
         diffChanges = combineLatest([
             getLeftDiff().entries,
@@ -80,6 +81,7 @@ export function getDiffChanges(): Observable<Map<string, ChangeInfo>> {
             map(([leftEntries, rightEntries, lineChanges]) => {
                 const changes = getChangedEntries(leftEntries, rightEntries);
                 lineChanges.forEach((counts, file) => {
+                    if (!isClassFilePath(file)) return;
                     const info = changes.get(file);
                     if (info) {
                         info.additions = counts.additions;
@@ -113,20 +115,20 @@ export function getDiffSummary(): Observable<DiffSummary> {
 
 export type ChangeState = "added" | "deleted" | "modified";
 
-async function getEntriesWithCRC(jar: MinecraftJar): Promise<Map<string, EntryInfo>> {
-    const entries = new Map<string, EntryInfo>();
+async function getEntriesWithCRC(jar: MinecraftJar): Promise<Map<ClassFilePath, EntryInfo>> {
+    const entries = new Map<ClassFilePath, EntryInfo>();
 
     for (const [path, file] of Object.entries(jar.jar.entries)) {
-        if (!path.endsWith('.class')) {
+        if (!isClassFilePath(path) || !file) {
             continue;
         }
 
-        const className = path.substring(0, path.length - 6);
+        const className = classNameFromClassFilePath(path);
         const lastSlash = path.lastIndexOf('/');
         const folder = lastSlash !== -1 ? path.substring(0, lastSlash + 1) : '';
         const fileName = path.substring(folder.length);
-        const baseFileName = fileName.includes('$') ? fileName.split('$')[0] : fileName.replace('.class', '');
-        const baseClassName = folder + baseFileName + '.class';
+        const baseFileName = fileName.includes('$') ? fileName.split('$')[0] : withoutClassExtension(fileName);
+        const baseClassName = toClassFilePath(folder + baseFileName);
 
         const existing = entries.get(baseClassName);
         if (existing) {
@@ -142,12 +144,12 @@ async function getEntriesWithCRC(jar: MinecraftJar): Promise<Map<string, EntryIn
 }
 
 function getChangedEntries(
-    leftEntries: Map<string, EntryInfo>,
-    rightEntries: Map<string, EntryInfo>
-): Map<string, ChangeInfo> {
-    const changes = new Map<string, ChangeInfo>();
+    leftEntries: Map<ClassFilePath, EntryInfo>,
+    rightEntries: Map<ClassFilePath, EntryInfo>
+): Map<ClassFilePath, ChangeInfo> {
+    const changes = new Map<ClassFilePath, ChangeInfo>();
 
-    const allKeys = new Set<string>([
+    const allKeys = new Set<ClassFilePath>([
         ...leftEntries.keys(),
         ...rightEntries.keys()
     ]);

--- a/src/logic/FindAllReferences.ts
+++ b/src/logic/FindAllReferences.ts
@@ -5,6 +5,7 @@ import { referencesQuery } from "./State";
 import type { Token } from "./Tokens";
 import type { DecompileResult } from "../workers/decompile/types";
 import type { ReferenceKey, ReferenceString } from "../workers/jar-index/types";
+import { toClassFilePath, toClassName, type ClassName } from "../utils/Names";
 
 export const referenceResults = referencesQuery
     .pipe(
@@ -73,7 +74,7 @@ function getQueryType(query: ReferenceKey): "class" | "method" | "field" {
 
 interface ReferenceNavigation {
     // The class to navigate to
-    className: string;
+    className: ClassName;
     // The reference being navigated to
     query: ReferenceKey;
     // The location of where the reference is found
@@ -83,8 +84,8 @@ interface ReferenceNavigation {
 export const nextReferenceNavigation = new BehaviorSubject<ReferenceNavigation | undefined>(undefined);
 
 export function goToReference(query: ReferenceKey, reference: ReferenceString) {
-    const className = reference.slice(2).split(":")[0].split('$')[0];
-    openCodeTab(className + ".class");
+    const className = toClassName(reference.slice(2).split(":")[0].split('$')[0]);
+    openCodeTab(toClassFilePath(className));
 
     if (reference.startsWith("c:")) {
         // Nothing to jump to
@@ -118,7 +119,7 @@ export function getNextJumpToken(decompileResult: DecompileResult): Token | unde
 
     { // First find the reference token
         const parts = reference.slice(2).split(":");
-        const classname = parts[0];
+        const classname = toClassName(parts[0]);
         const name = parts[1];
         const descriptor = parts[2];
         const expectedType = reference.startsWith("m:") ? "method" : "field";
@@ -169,7 +170,7 @@ export function getNextJumpToken(decompileResult: DecompileResult): Token | unde
         const token = decompileResult.tokens[i];
 
         // Special case for constructor reference
-        if (name == "<init>" && token.type == "class" && token.className == parts[0]) {
+        if (name == "<init>" && token.type == "class" && token.className == toClassName(parts[0])) {
             return token;
         }
 

--- a/src/logic/Inheritance.ts
+++ b/src/logic/Inheritance.ts
@@ -1,14 +1,15 @@
 import { BehaviorSubject, combineLatest, distinctUntilChanged, map, of, shareReplay, switchMap } from "rxjs";
 import { jarIndex, type ClassData } from "../workers/jar-index/client";
 import { minecraftJar } from "./MinecraftApi";
+import { classNameFromClassFilePath, isClassFilePath, type ClassName } from "../utils/Names";
 
 export class ClassNode {
-    readonly name: string;
+    readonly name: ClassName;
     parents: ClassNode[] = [];
     children: ClassNode[] = [];
     classData: ClassData | null = null;
 
-    constructor(name: string) {
+    constructor(name: ClassName) {
         this.name = name;
     }
 
@@ -25,9 +26,9 @@ export class ClassNode {
 }
 
 export class InheritanceIndex {
-    private readonly index = new Map<string, ClassNode>();
+    private readonly index = new Map<ClassName, ClassNode>();
 
-    addClass(className: string): ClassNode {
+    addClass(className: ClassName): ClassNode {
         let node = this.index.get(className);
         if (!node) {
             node = new ClassNode(className);
@@ -36,7 +37,7 @@ export class InheritanceIndex {
         return node;
     }
 
-    addParentChildLink(parentName: string, childName: string): void {
+    addParentChildLink(parentName: ClassName, childName: ClassName): void {
         const parent = this.addClass(parentName);
         const child = this.addClass(childName);
 
@@ -51,14 +52,14 @@ export class InheritanceIndex {
         }
     }
 
-    addChildParentLink(childName: string, parentName: string): void {
+    addChildParentLink(childName: ClassName, parentName: ClassName): void {
         this.addParentChildLink(parentName, childName);
     }
 }
 
 
 
-export const selectedInheritanceClassName = new BehaviorSubject<string | null>(null);
+export const selectedInheritanceClassName = new BehaviorSubject<ClassName | null>(null);
 
 export const inheritanceIndex = combineLatest([jarIndex, minecraftJar]).pipe(
     distinctUntilChanged(),
@@ -69,8 +70,8 @@ export const inheritanceIndex = combineLatest([jarIndex, minecraftJar]).pipe(
 
         const classNames = new Set(
             Object.keys(jarInstance.jar.entries)
-                .filter(name => name.endsWith(".class"))
-                .map(name => name.slice(0, -6))
+                .filter(isClassFilePath)
+                .map(classNameFromClassFilePath)
         );
 
         for (const classData of classDataArray) {

--- a/src/logic/JarFile.ts
+++ b/src/logic/JarFile.ts
@@ -2,6 +2,7 @@ import { BehaviorSubject, combineLatest, distinct, distinctUntilChanged, map, Ob
 import { minecraftJar } from './MinecraftApi';
 import { performSearch } from './Search';
 import { searchQuery } from './State';
+import { isClassFilePath, type ClassFilePath } from '../utils/Names';
 
 export const fileList = minecraftJar.pipe(
     distinctUntilChanged(),
@@ -10,7 +11,7 @@ export const fileList = minecraftJar.pipe(
 
 // File list that only contains outer class files
 export const classesList = fileList.pipe(
-    map(files => files.filter(file => file.endsWith('.class') && !file.includes('$')))
+    map(files => files.filter((file): file is ClassFilePath => isClassFilePath(file) && !file.includes('$')))
 );
 
 const debouncedSearchQuery: Observable<string> = searchQuery.pipe(
@@ -18,7 +19,7 @@ const debouncedSearchQuery: Observable<string> = searchQuery.pipe(
     distinctUntilChanged()
 );
 
-export const searchResults: Observable<string[]> = combineLatest([classesList, debouncedSearchQuery]).pipe(
+export const searchResults: Observable<ClassFilePath[]> = combineLatest([classesList, debouncedSearchQuery]).pipe(
     switchMap(([classes, query]) => {
         return [performSearch(query, classes)];
     })

--- a/src/logic/LineChanges.test.ts
+++ b/src/logic/LineChanges.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { countLineDiff, updateLineChanges, calculatedLineChanges } from './LineChanges';
+import { toJarEntryPath } from '../utils/Names';
+
+const file = toJarEntryPath;
 
 describe('LineChanges', () => {
     describe('countLineDiff', () => {
@@ -63,42 +66,42 @@ describe('LineChanges', () => {
         });
 
         it('should update the BehaviorSubject with new changes', () => {
-            updateLineChanges('file.java', 'line 1', 'line 1\nline 2');
-            const result = calculatedLineChanges.value.get('file.java');
+            updateLineChanges(file('file.java'), 'line 1', 'line 1\nline 2');
+            const result = calculatedLineChanges.value.get(file('file.java'));
             expect(result).toEqual({ additions: 1, deletions: 0 });
         });
 
         it('should not update the BehaviorSubject if changes are identical', () => {
-            const initialMap = new Map([['file.java', { additions: 1, deletions: 0 }]]);
+            const initialMap = new Map([[file('file.java'), { additions: 1, deletions: 0 }]]);
             calculatedLineChanges.next(initialMap);
 
-            updateLineChanges('file.java', 'line 1', 'line 1\nline 2');
+            updateLineChanges(file('file.java'), 'line 1', 'line 1\nline 2');
 
             expect(calculatedLineChanges.value).toBe(initialMap); // Reference should stay same
         });
 
         it('should add multiple files to the map', () => {
-            updateLineChanges('file1.java', 'a', 'a\nb');
-            updateLineChanges('file2.java', 'x', 'y');
+            updateLineChanges(file('file1.java'), 'a', 'a\nb');
+            updateLineChanges(file('file2.java'), 'x', 'y');
 
-            expect(calculatedLineChanges.value.get('file1.java')).toEqual({ additions: 1, deletions: 0 });
-            expect(calculatedLineChanges.value.get('file2.java')).toEqual({ additions: 1, deletions: 1 });
+            expect(calculatedLineChanges.value.get(file('file1.java'))).toEqual({ additions: 1, deletions: 0 });
+            expect(calculatedLineChanges.value.get(file('file2.java'))).toEqual({ additions: 1, deletions: 1 });
         });
 
         it('should evict old entries when reaching MAX_CALCULATED_LINE_CHANGES', () => {
             // Fill up to 500
             for (let i = 0; i < 500; i++) {
-                updateLineChanges(`file${i}.java`, '', 'line');
+                updateLineChanges(file(`file${i}.java`), '', 'line');
             }
             expect(calculatedLineChanges.value.size).toBe(500);
-            expect(calculatedLineChanges.value.has('file0.java')).toBe(true);
+            expect(calculatedLineChanges.value.has(file('file0.java'))).toBe(true);
 
             // Add 501st entry
-            updateLineChanges('file501.java', '', 'line');
+            updateLineChanges(file('file501.java'), '', 'line');
 
             expect(calculatedLineChanges.value.size).toBe(500);
-            expect(calculatedLineChanges.value.has('file0.java')).toBe(false); // First one should be evicted
-            expect(calculatedLineChanges.value.has('file501.java')).toBe(true);
+            expect(calculatedLineChanges.value.has(file('file0.java'))).toBe(false); // First one should be evicted
+            expect(calculatedLineChanges.value.has(file('file501.java'))).toBe(true);
         });
     });
 });

--- a/src/logic/LineChanges.ts
+++ b/src/logic/LineChanges.ts
@@ -1,8 +1,9 @@
 import { BehaviorSubject } from "rxjs";
+import type { JarEntryPath } from "../utils/Names";
 
 const MAX_CALCULATED_LINE_CHANGES = 500;
 
-export const calculatedLineChanges = new BehaviorSubject<Map<string, { additions: number, deletions: number; }>>(new Map());
+export const calculatedLineChanges = new BehaviorSubject<Map<JarEntryPath, { additions: number, deletions: number; }>>(new Map());
 
 /**
  * Simple line-based diff to count additions and deletions without external libraries.
@@ -70,7 +71,7 @@ export function countLineDiff(oldText: string, newText: string): { additions: nu
     };
 }
 
-export function updateLineChanges(file: string, leftSource: string, rightSource: string) {
+export function updateLineChanges(file: JarEntryPath, leftSource: string, rightSource: string) {
     const { additions, deletions } = countLineDiff(leftSource, rightSource);
 
     const current = calculatedLineChanges.value;

--- a/src/logic/Permalink.ts
+++ b/src/logic/Permalink.ts
@@ -1,11 +1,12 @@
 import { combineLatest } from "rxjs";
 import { resetPermalinkAffectingSettings, supportsPermalinking } from "./Settings";
 import { diffLeftSelectedMinecraftVersion, diffView, selectedFile, selectedLines, selectedMinecraftVersion } from "./State";
+import { toClassFilePath, withoutClassExtension, type ClassFilePath } from "../utils/Names";
 
 export interface State {
     version: number; // Allows us to change the permalink structure in the future
     minecraftVersion: string;
-    file: string | undefined;
+    file: ClassFilePath | undefined;
     selectedLines: {
         line: number;
         lineEnd?: number;
@@ -53,7 +54,7 @@ export const parsePathToState = (path: string): State | null => {
         return {
             version,
             minecraftVersion: rightMinecraftVersion,
-            file: filePath ? filePath + (filePath.endsWith('.class') ? '' : '.class') : undefined,
+            file: filePath ? toClassFilePath(filePath) : undefined,
             selectedLines: null,
             diff: { leftMinecraftVersion }
         };
@@ -70,7 +71,7 @@ export const parsePathToState = (path: string): State | null => {
     return {
         version,
         minecraftVersion,
-        file: filePath ? filePath + (filePath.endsWith('.class') ? '' : '.class') : undefined,
+        file: filePath ? toClassFilePath(filePath) : undefined,
         selectedLines: lineNumber ? { line: lineNumber, lineEnd: lineEnd || undefined } : null
     };
 };
@@ -130,7 +131,7 @@ if (typeof window !== "undefined") {
             }
 
             if (file) {
-                const className = file.split('/').pop()?.replace('.class', '') || file;
+                const className = withoutClassExtension(file.split('/').pop() || file);
                 document.title = className;
             } else {
                 document.title = "mcsrc.dev";
@@ -147,10 +148,10 @@ if (typeof window !== "undefined") {
             if (diffView) {
                 url += `diff/${diffLeftMinecraftVersion}/${minecraftVersion}`;
                 if (file) {
-                    url += `/${file.replace(".class", "")}`;
+                    url += `/${withoutClassExtension(file)}`;
                 }
             } else {
-                url += `${minecraftVersion}/${file!.replace(".class", "")}`;
+                url += `${minecraftVersion}/${withoutClassExtension(file!)}`;
 
                 if (selectedLines) {
                     const { line, lineEnd } = selectedLines;

--- a/src/logic/Search.ts
+++ b/src/logic/Search.ts
@@ -8,7 +8,7 @@ export function matchesCamelCase(className: string, query: string): boolean {
 }
 
 // Vibe coded mess that no one other than copilot or should read or touch :D
-export function performSearch(query: string, classes: string[]): string[] {
+export function performSearch<T extends string>(query: string, classes: T[]): T[] {
     if (query.length === 0) {
         return [];
     }
@@ -65,4 +65,4 @@ export function performSearch(query: string, classes: string[]): string[] {
     return results;
 }
 
-
+import type { ClassFilePath } from "../utils/Names";

--- a/src/logic/State.ts
+++ b/src/logic/State.ts
@@ -2,6 +2,8 @@ import { BehaviorSubject } from "rxjs";
 import { pairwise } from "rxjs/operators";
 import { Tab, CodeTab } from "./tabs";
 import { getInitialState } from "./Permalink";
+import type { ClassFilePath } from "../utils/Names";
+import type { ReferenceKey } from "../workers/jar-index/types";
 
 const initialState = getInitialState();
 
@@ -10,13 +12,13 @@ const initialState = getInitialState();
 export const selectedMinecraftVersion = new BehaviorSubject<string | null>(initialState.minecraftVersion);
 
 export const mobileDrawerOpen = new BehaviorSubject(false);
-export const selectedFile = new BehaviorSubject<string | undefined>(initialState.file);
+export const selectedFile = new BehaviorSubject<ClassFilePath | undefined>(initialState.file);
 const initialTab = initialState.file ? new CodeTab(initialState.file) : null;
 export const openTab = new BehaviorSubject<Tab | null>(initialTab);
 export const openTabs = new BehaviorSubject<Tab[]>(initialTab ? [initialTab] : []);
 export const tabHistory = new BehaviorSubject<string[]>(initialState.file ? [initialState.file] : []);
 export const searchQuery = new BehaviorSubject("");
-export const referencesQuery = new BehaviorSubject("");
+export const referencesQuery = new BehaviorSubject<ReferenceKey | "">("");
 
 export interface SelectedLines {
     line: number;

--- a/src/logic/Tokens.ts
+++ b/src/logic/Tokens.ts
@@ -1,4 +1,5 @@
 import type { DecompileResult } from "../workers/decompile/types.ts";
+import type { ClassName } from "../utils/Names";
 
 export type TokenType = 'class' | 'field' | 'method' | 'parameter' | 'local';
 
@@ -8,7 +9,7 @@ interface BaseToken {
     // The length of the token in characters
     length: number;
     // The name of the class this token represents
-    className: string;
+    className: ClassName;
     // Whether this token is a declaration or a reference
     declaration: boolean;
 }

--- a/src/logic/tabs/CodeTab.ts
+++ b/src/logic/tabs/CodeTab.ts
@@ -1,11 +1,17 @@
 import type { editor } from "monaco-editor";
 import { Tab } from "./Tabs";
 import { selectedFile, tabHistory } from "../State";
+import type { ClassFilePath } from "../../utils/Names";
 
 export class CodeTab extends Tab {
+    public declare key: ClassFilePath;
     public editorRef: editor.IStandaloneCodeEditor | null = null;
     public viewState: editor.ICodeEditorViewState | null = null;
     public model: editor.ITextModel | null = null;
+
+    public constructor(key: ClassFilePath) {
+        super(key);
+    }
 
     public open() {
         super.open();
@@ -80,6 +86,6 @@ export class CodeTab extends Tab {
     public openLastTabFromHistory(): void {
         super.openLastTabFromHistory();
         if (tabHistory.value.length > 0) return;
-        selectedFile.next("");
+        selectedFile.next(undefined);
     }
 }

--- a/src/logic/tabs/InheritanceViewTab.ts
+++ b/src/logic/tabs/InheritanceViewTab.ts
@@ -2,6 +2,7 @@ import type { TreeDataNode } from "antd";
 import { Tab } from "./Tabs";
 import type { Key } from "react";
 import { selectedFile, tabHistory } from "../State";
+import { toClassName, type ClassName } from "../../utils/Names";
 
 export class InheritanceViewTab extends Tab {
     public innerTabs: {
@@ -34,7 +35,7 @@ export class InheritanceViewTab extends Tab {
             }
         };
 
-    private async setSelectedInheritanceClassName(key: string | null) {
+    private async setSelectedInheritanceClassName(key: ClassName | null) {
         // We need to unfortunately do an async import here because else we'll get
         // a circular import (minecraftJar)
         const { selectedInheritanceClassName } = await import("../Inheritance");
@@ -44,8 +45,8 @@ export class InheritanceViewTab extends Tab {
     public open(): void {
         super.open();
 
-        selectedFile.next("");
-        this.setSelectedInheritanceClassName(this.key.replace("hierarchy::", ""));
+        selectedFile.next(undefined);
+        this.setSelectedInheritanceClassName(toClassName(this.key.replace("hierarchy::", "")));
     }
 
     protected onBlur(): void {
@@ -61,6 +62,6 @@ export class InheritanceViewTab extends Tab {
     public openLastTabFromHistory(): void {
         super.openLastTabFromHistory();
         if (tabHistory.value.length > 0) return;
-        this.setSelectedInheritanceClassName("");
+        this.setSelectedInheritanceClassName(null);
     }
 }

--- a/src/logic/tabs/Tabs.ts
+++ b/src/logic/tabs/Tabs.ts
@@ -1,6 +1,7 @@
 import { openTabs, tabHistory, openTab } from "../State";
 import { enableTabs } from "../Settings";
 import { CodeTab, InheritanceViewTab } from "./index";
+import type { ClassFilePath } from "../../utils/Names";
 
 export abstract class Tab {
     public key: string;
@@ -86,9 +87,9 @@ export const getOpenTab = <T extends Tab>(): T | null => {
     return openTab.value as T | null;
 };
 
-const openTabOfType = <T extends Tab>(
-    key: string,
-    TabClass: new (key: string) => T
+const openTabOfType = <K extends string, T extends Tab>(
+    key: K,
+    TabClass: new (key: K) => T
 ) => {
     const existing = openTabs.value.find(
         t => t.key === key && t instanceof TabClass
@@ -110,7 +111,7 @@ export const openUnknownTypeTab = (key: string) => {
     existing.open();
 };
 
-export const openCodeTab = (key: string) => openTabOfType(key, CodeTab);
+export const openCodeTab = (key: ClassFilePath) => openTabOfType(key, CodeTab);
 export const openInheritanceViewTab = (key: string) => openTabOfType(key, InheritanceViewTab);
 
 export const closeTab = (key: string) => {

--- a/src/ui/Code.tsx
+++ b/src/ui/Code.tsx
@@ -34,6 +34,7 @@ import {
 } from './CodeExtensions';
 import { bytecode } from '../logic/Settings';
 import { selectedFile, diffView, openTabs, selectedLines, tabHistory, referencesQuery, mobileDrawerOpen } from '../logic/State';
+import { toClassFilePath } from '../utils/Names';
 
 const IS_ANDROID_CHROME = /Android/.test(navigator.userAgent) && /Chrome/.test(navigator.userAgent);
 
@@ -67,7 +68,7 @@ const Code = () => {
             const decorations = decompileResult.tokens.map(token => {
                 const startPos = model.getPositionAt(token.start);
                 const endPos = model.getPositionAt(token.start + token.length);
-                const canGoTo = !token.declaration && classList && classList.includes(token.className + ".class");
+                const canGoTo = !token.declaration && classList && classList.includes(toClassFilePath(token.className));
 
                 return {
                     range: new Range(startPos.lineNumber, startPos.column, endPos.lineNumber, endPos.column),
@@ -298,7 +299,7 @@ const Code = () => {
     useEffect(() => {
         if (!editorRef.current || !decompileResult || !tokenJump) return;
 
-        if (decompileResult.className + ".class" === tokenJump.className) {
+        if (toClassFilePath(decompileResult.className) === tokenJump.className) {
             requestAnimationFrame(() => {
                 if (editorRef.current && decompileResult) {
                     jumpToToken(decompileResult, tokenJump.targetType, tokenJump.target, editorRef.current);

--- a/src/ui/CodeContextActions.ts
+++ b/src/ui/CodeContextActions.ts
@@ -2,6 +2,8 @@ import type { editor } from "monaco-editor";
 import { findTokenAtPosition } from './CodeUtils';
 import type { DecompileResult } from "../workers/decompile/types";
 import { openInheritanceViewTab } from "../logic/tabs";
+import { dottedClassNameFromClassName, type ClassFilePath, type ClassName } from "../utils/Names";
+import type { ReferenceKey } from "../workers/jar-index/types";
 
 export const IS_DEFINITION_CONTEXT_KEY_NAME = "is_definition";
 
@@ -11,7 +13,7 @@ async function setClipboard(text: string): Promise<void> {
 
 export function createCopyAwAction(
     decompileResultRef: { current: DecompileResult | undefined; },
-    classListRef: { current: string[] | undefined; },
+    classListRef: { current: ClassFilePath[] | undefined; },
     messageApi: { error: (msg: string) => void; success: (msg: string) => void; }
 ) {
     return {
@@ -48,7 +50,7 @@ export function createCopyAwAction(
 
 export function createCopyAtAction(
     decompileResultRef: { current: DecompileResult | undefined; },
-    classListRef: { current: string[] | undefined; },
+    classListRef: { current: ClassFilePath[] | undefined; },
     messageApi: { error: (msg: string) => void; success: (msg: string) => void; }
 ) {
     return {
@@ -65,13 +67,13 @@ export function createCopyAtAction(
 
             switch (token.type) {
                 case "class":
-                    await setClipboard(`public ${token.className.replaceAll("/", ".")}`);
+                    await setClipboard(`public ${dottedClassNameFromClassName(token.className)}`);
                     break;
                 case "field":
-                    await setClipboard(`public ${token.className.replaceAll("/", ".")} ${token.name}`);
+                    await setClipboard(`public ${dottedClassNameFromClassName(token.className)} ${token.name}`);
                     break;
                 case "method":
-                    await setClipboard(`public ${token.className.replaceAll("/", ".")} ${token.name}${token.descriptor}`);
+                    await setClipboard(`public ${dottedClassNameFromClassName(token.className)} ${token.name}${token.descriptor}`);
                     break;
                 default:
                     messageApi.error("Token is not a class, field, or method.");
@@ -85,7 +87,7 @@ export function createCopyAtAction(
 
 export function createCopyMixinAction(
     decompileResultRef: { current: DecompileResult | undefined; },
-    classListRef: { current: string[] | undefined; },
+    classListRef: { current: ClassFilePath[] | undefined; },
     messageApi: { error: (msg: string) => void; success: (msg: string) => void; }
 ) {
     return {
@@ -122,9 +124,9 @@ export function createCopyMixinAction(
 
 export function createFindAllReferencesAction(
     decompileResultRef: { current: DecompileResult | undefined; },
-    classListRef: { current: string[] | undefined; },
+    classListRef: { current: ClassFilePath[] | undefined; },
     messageApi: { error: (msg: string) => void; },
-    referenceQueryNext: (value: string) => void
+    referenceQueryNext: (value: ReferenceKey) => void
 ) {
     return {
         id: 'find_all_references',
@@ -160,7 +162,7 @@ export function createFindAllReferencesAction(
 export function createViewInheritanceAction(
     decompileResultRef: { current: DecompileResult | undefined; },
     messageApi: { error: (msg: string) => void; },
-    selectedInheritanceClassNameNext: (value: string) => void
+    selectedInheritanceClassNameNext: (value: ClassName) => void
 ) {
     return {
         id: 'view_inheritance',
@@ -173,7 +175,7 @@ export function createViewInheritanceAction(
                 return;
             }
 
-            const className = decompileResultRef.current.className.replace('.class', '');
+            const className = decompileResultRef.current.className;
             console.log(`Viewing inheritance for ${className}`);
             openInheritanceViewTab(`hierarchy::${className}`);
         }

--- a/src/ui/CodeExtensions.ts
+++ b/src/ui/CodeExtensions.ts
@@ -5,16 +5,17 @@ import { getTokenLocation } from '../logic/Tokens';
 import { selectedFile } from "../logic/State";
 import type { DecompileResult } from "../workers/decompile/types";
 import { BehaviorSubject } from "rxjs";
+import { classNameFromClassFilePath, outerClassFilePath, toClassFilePath, type ClassFilePath } from "../utils/Names";
 
 export type TokenJumpTarget = {
-    className: string;
+    className: ClassFilePath;
     targetType: 'method' | 'field' | 'class';
     target: string;
 };
 
 export const pendingTokenJump = new BehaviorSubject<TokenJumpTarget | null>(null);
 
-export function requestTokenJump(className: string, targetType: 'method' | 'field' | 'class', target: string) {
+export function requestTokenJump(className: ClassFilePath, targetType: 'method' | 'field' | 'class', target: string) {
     pendingTokenJump.next({ className, targetType, target });
 }
 
@@ -83,8 +84,8 @@ export function createDefinitionProvider(
                 }
 
                 if (targetOffset >= token.start && targetOffset <= token.start + token.length) {
-                    const className = token.className + ".class";
-                    const baseClassName = token.className.split('$')[0] + ".class";
+                    const className = toClassFilePath(token.className);
+                    const baseClassName = toClassFilePath(token.className.split('$')[0]);
                     console.log(`Found token for definition: ${className} at offset ${token.start}`);
 
                     if (classList && (classList.includes(className) || classList.includes(baseClassName))) {
@@ -125,8 +126,8 @@ export function createEditorOpener(
                 return false;
             }
 
-            const className = resource.path.substring(1);
-            const baseClassName = className.includes('$') ? className.split('$')[0] + ".class" : className;
+            const className = toClassFilePath(resource.path.substring(1));
+            const baseClassName = className.includes('$') ? outerClassFilePath(className) : className;
 
             const jumpInSameFile = baseClassName === selectedFile.value;
             const fragment = resource.fragment.split(":") as [string, ...string[]];
@@ -152,7 +153,7 @@ export function createEditorOpener(
                 }
             } else if (baseClassName != className) {
                 // Handle inner class navigation
-                const innerClassName = className.replace('.class', '');
+                const innerClassName = classNameFromClassFilePath(className);
                 // Always use the queue, even for same-file jumps
                 requestTokenJump(baseClassName, 'class', innerClassName);
                 if (!jumpInSameFile) {

--- a/src/ui/CodeHoverProvider.ts
+++ b/src/ui/CodeHoverProvider.ts
@@ -2,6 +2,7 @@ import { editor, type IMarkdownString, type IPosition, Range } from "monaco-edit
 import { type Token } from '../logic/Tokens';
 import { findTokenAtPosition } from './CodeUtils';
 import type { DecompileResult } from "../workers/decompile/types";
+import { dottedClassNameFromClassName, toClassName, type ClassFilePath } from "../utils/Names";
 
 interface IntegerLiteral {
     value: number;
@@ -100,7 +101,7 @@ export function parseDescriptor(descriptor: string): string {
 
         if (desc[index] === 'L') {
             endIndex = desc.indexOf(';', index);
-            type = desc.substring(index + 1, endIndex).replace(/\//g, '.');
+            type = dottedClassNameFromClassName(toClassName(desc.substring(index + 1, endIndex)));
             endIndex++;
         } else {
             type = typeMap[desc[index]] || desc[index];
@@ -137,7 +138,7 @@ export function parseDescriptor(descriptor: string): string {
 export function createHoverProvider(
     editorRef: { current: editor.ICodeEditor | null },
     decompileResultRef: { current: DecompileResult | undefined },
-    classListRef: { current: string[] | undefined }
+    classListRef: { current: ClassFilePath[] | undefined }
 ) {
     return {
         provideHover(model: editor.ITextModel, position: IPosition) {
@@ -152,7 +153,7 @@ export function createHoverProvider(
                 const contents: IMarkdownString[] = [];
 
                 // Format class name for display
-                const formattedClassName = token.className.replace(/\//g, '.');
+                const formattedClassName = dottedClassNameFromClassName(token.className);
 
                 switch (token.type) {
                     case 'class':

--- a/src/ui/CodeUtils.ts
+++ b/src/ui/CodeUtils.ts
@@ -1,10 +1,11 @@
 import { editor } from "monaco-editor";
 import { type Token } from '../logic/Tokens';
+import { toClassFilePath, type ClassFilePath } from "../utils/Names";
 
 export function findTokenAtPosition(
     editor: editor.ICodeEditor,
     decompileResult: { tokens: Token[]; } | undefined,
-    classList: string[] | undefined,
+    classList: ClassFilePath[] | undefined,
     useClassList = true
 ): Token | null {
     const model = editor.getModel();
@@ -29,8 +30,7 @@ export function findTokenAtPosition(
 
     for (const token of decompileResult.tokens) {
         if (targetOffset >= token.start && targetOffset <= token.start + token.length) {
-            const baseClassName = token.className.split('$')[0];
-            const className = baseClassName + ".class";
+            const className = toClassFilePath(token.className.split('$')[0]);
             if (!useClassList || classList!.includes(className)) {
                 return token;
             }

--- a/src/ui/FileList.tsx
+++ b/src/ui/FileList.tsx
@@ -14,6 +14,7 @@ import { selectedFile, referencesQuery } from '../logic/State';
 import { autoJarIndex, compactPackages } from '../logic/Settings';
 import { jarIndex, type ClassData } from '../workers/jar-index/client';
 import { ClassDataIcon, JavaIcon, PackageIcon } from './intellij-icons';
+import { classNameFromClassFilePath, dottedClassNameFromClassName, isClassFilePath, toClassName, withoutClassExtension, type ClassFilePath } from '../utils/Names';
 
 const classData: Observable<Map<string, ClassData> | null> = combineLatest([
     jarIndex,
@@ -44,7 +45,7 @@ const fileTree: Observable<TreeDataNode[]> = combineLatest([
         for (const classPath of classNames) {
             if (classPath.includes('$')) continue;
 
-            const className = classPath.replace('.class', '');
+            const className = classNameFromClassFilePath(classPath);
             const i = className.lastIndexOf('/');
             const dirPath = className.slice(0, i);
 
@@ -123,10 +124,10 @@ function getPathKeys(filePath: string): Key[] {
     return result;
 }
 
-const handleCopyContent = async (path: string, jar: MinecraftJar) => {
+const handleCopyContent = async (path: ClassFilePath, jar: MinecraftJar) => {
     try {
         message.loading({ content: 'Decompiling...', key: 'copy-content' });
-        const result = await decompileClass(path, jar.jar);
+        const result = await decompileClass(classNameFromClassFilePath(path), jar.jar);
         await navigator.clipboard.writeText(result.source);
         message.success({ content: 'Content copied to clipboard', key: 'copy-content' });
     } catch (e) {
@@ -144,16 +145,16 @@ interface ContextMenuInfo {
 
 const getMenuItems = (
     contextMenu: ContextMenuInfo | null,
-    handleCopyItem: (path: string) => void,
+    handleCopyItem: (path: ClassFilePath) => void,
     jar: MinecraftJar | undefined
 ): MenuProps['items'] => {
     if (!contextMenu) return [];
 
     const path = contextMenu.key;
-    const isFile = path.endsWith('.class');
-    const packagePath = path.replace(/\//g, '.').replace('.class', '');
+    const isFile = isClassFilePath(path);
+    const packagePath = isFile ? dottedClassNameFromClassName(classNameFromClassFilePath(path)) : withoutClassExtension(path);
     const filename = path.split('/').pop() || '';
-    const linkPath = path.replace('.class', '');
+    const linkPath = withoutClassExtension(path);
     const link = jar ? `https://mcsrc.dev/1/${jar.version}/${linkPath}` : '';
 
     const renderLabel = (title: string, value: string) => (
@@ -213,15 +214,16 @@ const getMenuItems = (
         {
             key: 'copy-content',
             label: 'Copy File Content',
-            onClick: () => handleCopyItem(contextMenu.key),
+            onClick: () => {
+                if (isFile) handleCopyItem(path);
+            },
             disabled: !isFile
         },
         {
             key: 'find-all-references',
             label: 'Find All References',
             onClick: () => {
-                const cleanPath = path.replace('.class', '');
-                referencesQuery.next(cleanPath);
+                referencesQuery.next(toClassName(path));
             },
             disabled: !isFile
         },
@@ -237,8 +239,9 @@ const FileList = () => {
     const classes = useObservable(classesList);
     const onSelect: TreeProps['onSelect'] = useCallback((selectedKeys: Key[]) => {
         if (selectedKeys.length === 0) return;
-        if (!classes || !classes.includes(selectedKeys[0] as string)) return;
-        openCodeTab(selectedKeys.join("/"));
+        const key = selectedKeys[0];
+        if (typeof key !== "string" || !isClassFilePath(key) || !classes.includes(key)) return;
+        openCodeTab(key);
     }, [classes]);
 
     const treeData = useObservable(fileTree);

--- a/src/ui/FilepathHeader.tsx
+++ b/src/ui/FilepathHeader.tsx
@@ -3,6 +3,7 @@ import { useObservable } from "../utils/UseObservable";
 import { getDiffChanges } from "../logic/Diff";
 import { combineLatest, map } from "rxjs";
 import { selectedFile, diffView } from "../logic/State";
+import { withoutClassExtension } from "../utils/Names";
 
 const changeInfoObs = combineLatest([selectedFile, getDiffChanges(), diffView]).pipe(
     map(([file, changes, isDiff]) => {
@@ -33,7 +34,7 @@ export const FilepathHeader = () => {
                 direction: "rtl",
                 color: token.colorText
             }}>
-                {info.replace(".class", "").split("/").map((path, i, arr) => (
+                {withoutClassExtension(info).split("/").map((path, i, arr) => (
                     <span key={path}>
                         <span style={{ color: i < arr.length - 1 ? token.colorTextTertiary : token.colorText }}>{path}</span>
                         {i < arr.length - 1 && <span style={{ color: token.colorTextTertiary }}>/</span>}

--- a/src/ui/ReferenceResults.tsx
+++ b/src/ui/ReferenceResults.tsx
@@ -5,35 +5,35 @@ import { openCodeTab } from "../logic/tabs";
 import { referencesQuery } from "../logic/State";
 import type { ReferenceString } from "../workers/jar-index/types";
 import { theme } from "antd";
+import { toClassFilePath, toClassName, type ClassName } from "../utils/Names";
 
-function getUsageClass(usage: ReferenceString): string {
+function getUsageClass(usage: ReferenceString): ClassName {
     if (usage.startsWith("m:") || usage.startsWith("f:")) {
         const parts = usage.slice(2).split(":");
-        return parts[0];
+        return toClassName(parts[0]);
     }
 
     // class usage
-    return usage;
+    return toClassName(usage.slice(2));
 }
 
 interface ReferenceGroup {
-    className: string;
+    className: ClassName;
     references: ReferenceString[];
 }
 
 const groupedResults: Observable<ReferenceGroup[]> = referenceResults.pipe(
     map(results => {
-        const groups: Record<string, ReferenceString[]> = {};
+        const groups = new Map<ClassName, ReferenceString[]>();
 
         for (const usage of results) {
             const className = getUsageClass(usage);
-            if (!groups[className]) {
-                groups[className] = [];
-            }
-            groups[className].push(usage);
+            const references = groups.get(className) || [];
+            references.push(usage);
+            groups.set(className, references);
         }
 
-        return Object.entries(groups).map(([className, references]) => ({
+        return Array.from(groups.entries()).map(([className, references]) => ({
             className,
             references
         }));
@@ -51,7 +51,7 @@ const UsageGroupItem = ({ group }: UsageGroupItemProps) => {
     return (
         <div style={{ marginBottom: "4px" }}>
             <div
-                onClick={() => openCodeTab(group.className + ".class")}
+                onClick={() => openCodeTab(toClassFilePath(group.className))}
                 style={{
                     cursor: "pointer",
                     fontSize: "13px",
@@ -68,7 +68,9 @@ const UsageGroupItem = ({ group }: UsageGroupItemProps) => {
                 {group.references.map((reference, index) => (
                     <div
                         key={index}
-                        onClick={() => goToReference(query, reference)}
+                        onClick={() => {
+                            if (query) goToReference(query, reference);
+                        }}
                         style={{
                             cursor: "pointer",
                             fontSize: "12px",

--- a/src/ui/SearchResults.tsx
+++ b/src/ui/SearchResults.tsx
@@ -2,12 +2,13 @@ import { List } from "antd";
 import { searchResults } from "../logic/JarFile";
 import { useObservable } from "../utils/UseObservable";
 import { openCodeTab } from "../logic/tabs";
+import { withoutClassExtension, type ClassFilePath } from "../utils/Names";
 
 const SearchResults = () => {
     const results = useObservable(searchResults);
 
     return (
-        <List
+        <List<ClassFilePath>
             size="small"
             dataSource={results}
             renderItem={(item) => (
@@ -22,7 +23,7 @@ const SearchResults = () => {
                     onMouseEnter={(e) => e.currentTarget.style.backgroundColor = 'rgba(255, 255, 255, 0.1)'}
                     onMouseLeave={(e) => e.currentTarget.style.backgroundColor = 'transparent'}
                 >
-                    {item.replace(/\.class$/, '')}
+                    {withoutClassExtension(item)}
                 </List.Item>
             )}
         />

--- a/src/ui/SideBar.tsx
+++ b/src/ui/SideBar.tsx
@@ -50,7 +50,7 @@ const SideBar = () => {
                         Back
                     </Button>
                     <div style={{ fontSize: "12px", textAlign: "center" }}>
-                        References of: {formatReferenceQuery(currentReferenceQuery || "")}
+                        References of: {currentReferenceQuery ? formatReferenceQuery(currentReferenceQuery) : ""}
                     </div>
                 </>
             ) : (

--- a/src/ui/TabsComponent.tsx
+++ b/src/ui/TabsComponent.tsx
@@ -4,6 +4,7 @@ import { closeTab, setTabPosition, closeOtherTabs, openUnknownTypeTab, Inheritan
 import React, { useEffect, useRef, useState } from "react";
 import { openTabs, openTab } from "../logic/State";
 import { HierarchyIcon } from "./intellij-icons";
+import { withoutClassExtension } from "../utils/Names";
 
 export const TabsComponent = () => {
     // variables - tabs
@@ -26,6 +27,8 @@ export const TabsComponent = () => {
 
     // variables - tab ghost image
     const ghostImage = useRef<HTMLElement | null>(null);
+
+    const getTabLabel = (key: string) => withoutClassExtension(key).split("/").pop();
 
     // helpers
     const getRects = () => {
@@ -221,7 +224,7 @@ export const TabsComponent = () => {
                                 ref={(el) => { tabRefs.current[tab.key] = el; }}
                                 style={{ userSelect: "none", display: "inline" }}
                             >
-                                {tab.key.replace(".class", "").split("/").pop()}
+                                {getTabLabel(tab.key)}
                             </div>
                         ),
                         icon: (

--- a/src/ui/diff/DiffCode.tsx
+++ b/src/ui/diff/DiffCode.tsx
@@ -16,6 +16,7 @@ import {
     registerDiffNavigator,
     type DiffDirection
 } from './DiffNavigation';
+import { classNameFromClassFilePath } from '../../utils/Names';
 
 const IS_ANDROID_CHROME = /Android/.test(navigator.userAgent) && /Chrome/.test(navigator.userAgent);
 
@@ -41,7 +42,7 @@ const DiffCode = () => {
         if (!leftResult) return;
         if (!rightResult) return;
 
-        const currentClass = currentPath.replace(".class", "");
+        const currentClass = classNameFromClassFilePath(currentPath);
         if (leftResult.className !== currentClass) return;
         if (rightResult.className !== currentClass) return;
 

--- a/src/ui/diff/DiffViewFileList.tsx
+++ b/src/ui/diff/DiffViewFileList.tsx
@@ -13,6 +13,7 @@ import { selectedFile } from "../../logic/State";
 import { openCodeTab } from "../../logic/tabs";
 import { useObservable } from "../../utils/UseObservable";
 import { pendingDiffJump } from "./DiffNavigation";
+import { withoutClassExtension, type ClassFilePath } from "../../utils/Names";
 
 const statusColors: Record<ChangeState, string> = {
     modified: "gold",
@@ -23,8 +24,8 @@ const statusColors: Record<ChangeState, string> = {
 const searchQuery = new BehaviorSubject("");
 
 interface DiffEntry {
-    key: string;
-    file: string;
+    key: ClassFilePath;
+    file: ClassFilePath;
     statusInfo: ChangeInfo;
 }
 
@@ -112,7 +113,7 @@ interface DiffFileRowProps {
 }
 
 const DiffFileRow = memo(({ entry, selected, disabled }: DiffFileRowProps) => {
-    const file = entry.file.replace(".class", "");
+    const file = withoutClassExtension(entry.file);
     const segments = file.split("/");
     const name = segments.at(-1) || file;
     const path = segments.slice(0, -1).join("/");

--- a/src/ui/inheritance/InheritanceGraph.tsx
+++ b/src/ui/inheritance/InheritanceGraph.tsx
@@ -5,6 +5,7 @@ import { isInterface, isAbstract } from "../../utils/Classfile";
 import { useLayoutEffect } from "react";
 import dagre from "dagre";
 import { InheritanceViewTab, openCodeTab } from "../../logic/tabs";
+import { toClassFilePath, toClassName } from "../../utils/Names";
 
 function buildGraphData(classNode: ClassNode): { nodes: Node[]; edges: Edge[]; } {
     const nodes: Node[] = [];
@@ -202,7 +203,7 @@ const InheritanceGraphInner = ({ tab, data }: { tab: InheritanceViewTab; data: C
         <ReactFlow
             nodes={nodes}
             edges={edges}
-            onNodeClick={(_, { id }) => openCodeTab(`${id}.class`)}
+            onNodeClick={(_, { id }) => openCodeTab(toClassFilePath(toClassName(id)))}
             onMoveEnd={onMoveEnd}
             defaultViewport={tab.innerTabs.graph.viewport}
             proOptions={{ hideAttribution: true }}

--- a/src/ui/inheritance/InheritanceTree.tsx
+++ b/src/ui/inheritance/InheritanceTree.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, type Key } from "react";
 import { ClassNode } from "../../logic/Inheritance";
 import { InheritanceViewTab, openCodeTab } from "../../logic/tabs";
 import { ClassDataIcon } from "../intellij-icons";
+import { dottedClassNameFromClassName, toClassFilePath, toClassName } from "../../utils/Names";
 
 function getSimpleClassName(fullName: string): string {
     const i = fullName.lastIndexOf('/');
@@ -15,7 +16,7 @@ function renderIcon(node: ClassNode) {
 }
 
 function renderTitle(node: ClassNode) {
-    const fullName = node.name.replaceAll('/', '.');
+    const fullName = dottedClassNameFromClassName(node.name);
 
     return (
         <span>
@@ -93,8 +94,7 @@ const InheritanceTree = ({ tab, data }: { tab: InheritanceViewTab, data: ClassNo
         const selected = selectedKeys[0];
         if (!selected) return;
 
-        // Convert internal class name format (e.g., "net/minecraft/ChatFormatting") to file path
-        openCodeTab(`${selected}.class`);
+        openCodeTab(toClassFilePath(toClassName(String(selected))));
     }, []);
 
     const scrollRef = useRef<HTMLDivElement>(null);

--- a/src/utils/Jar.ts
+++ b/src/utils/Jar.ts
@@ -1,9 +1,10 @@
 import { read, type Entry, type Reader, type Zip, readBlob } from "@katana-project/zip";
+import type { JarEntryPath } from "./Names";
 
 export interface Jar {
     name: string;
     blob: Blob;
-    entries: { [key: string]: Entry; };
+    entries: Partial<Record<JarEntryPath, Entry>>;
 }
 
 export async function openJar(name: string, blob: Blob): Promise<Jar> {
@@ -26,14 +27,14 @@ class JarImpl implements Jar {
     private zip: Zip;
     public name: string;
     public blob: Blob;
-    public entries: { [key: string]: Entry; } = {};
+    public entries: Partial<Record<JarEntryPath, Entry>> = {};
 
     constructor(name: string, blob: Blob, zip: Zip) {
         this.name = name;
         this.blob = blob;
         this.zip = zip;
         zip.entries.forEach(entry => {
-            this.entries[entry.name] = entry;
+            this.entries[entry.name as JarEntryPath] = entry;
         });
     }
 }

--- a/src/utils/Names.ts
+++ b/src/utils/Names.ts
@@ -1,0 +1,73 @@
+// These make each string type distinct at compile time, without changing the runtime type.
+declare const classNameBrand: unique symbol;
+declare const dottedClassNameBrand: unique symbol;
+declare const classFilePathBrand: unique symbol;
+declare const jarEntryPathBrand: unique symbol;
+
+export type JarEntryPath = string & { readonly [jarEntryPathBrand]: "JarEntryPath"; };
+// Examples: net/minecraft/ChatFormatting, net/minecraft/world/level/Level$ExplosionInteraction
+export type ClassName = string & { readonly [classNameBrand]: "ClassName"; };
+// Examples: net.minecraft.ChatFormatting, net.minecraft.world.level.Level$ExplosionInteraction
+export type DottedClassName = string & { readonly [dottedClassNameBrand]: "DottedClassName"; };
+// Examples: net/minecraft/ChatFormatting.class, net/minecraft/world/level/Level$ExplosionInteraction.class
+export type ClassFilePath = `${string}.class` & JarEntryPath & { readonly [classFilePathBrand]: "ClassFilePath"; };
+
+// net/minecraft/ChatFormatting.class -> net/minecraft/ChatFormatting
+export function toClassName(value: string): ClassName {
+    return value.replace(/\.class$/, "") as ClassName;
+}
+
+// net.minecraft.ChatFormatting -> net/minecraft/ChatFormatting
+export function classNameFromDottedClassName(value: DottedClassName | string): ClassName {
+    return value.replaceAll(".", "/") as ClassName;
+}
+
+// net.minecraft.ChatFormatting -> net.minecraft.ChatFormatting
+export function toDottedClassName(value: string): DottedClassName {
+    return value as DottedClassName;
+}
+
+// net/minecraft/ChatFormatting -> net.minecraft.ChatFormatting
+export function dottedClassNameFromClassName(value: ClassName): DottedClassName {
+    return value.replaceAll("/", ".") as DottedClassName;
+}
+
+// net.minecraft.world.level.Level$ExplosionInteraction -> Level$ExplosionInteraction
+export function simpleDottedClassName(value: DottedClassName): string {
+    return value.split(".").pop() || value;
+}
+
+// net/minecraft/ChatFormatting -> net/minecraft/ChatFormatting.class
+export function toClassFilePath(value: ClassName | string): ClassFilePath {
+    return (value.endsWith(".class") ? value : `${value}.class`) as ClassFilePath;
+}
+
+// assets/minecraft/lang/en_us.json -> assets/minecraft/lang/en_us.json
+export function toJarEntryPath(value: string): JarEntryPath {
+    return value as JarEntryPath;
+}
+
+// net/minecraft/world/level/Level$ExplosionInteraction.class -> net/minecraft/world/level/Level$ExplosionInteraction
+export function classNameFromClassFilePath(path: ClassFilePath): ClassName {
+    return path.slice(0, -".class".length) as ClassName;
+}
+
+// true for net/minecraft/ChatFormatting.class, false for assets/minecraft/lang/en_us.json
+export function isClassFilePath(path: string): path is ClassFilePath {
+    return path.endsWith(".class");
+}
+
+// net/minecraft/ChatFormatting.class -> net/minecraft/ChatFormatting
+export function withoutClassExtension(path: ClassFilePath | string): string {
+    return path.replace(/\.class$/, "");
+}
+
+// net/minecraft/world/level/Level$ExplosionInteraction -> net/minecraft/world/level/Level
+export function outerClassName(className: ClassName): ClassName {
+    return className.split("$")[0] as ClassName;
+}
+
+// net/minecraft/world/level/Level$ExplosionInteraction.class -> net/minecraft/world/level/Level.class
+export function outerClassFilePath(path: ClassFilePath): ClassFilePath {
+    return toClassFilePath(outerClassName(classNameFromClassFilePath(path)));
+}

--- a/src/workers/decompile/client.ts
+++ b/src/workers/decompile/client.ts
@@ -3,6 +3,7 @@ import type * as vf from "../../logic/vf";
 import { DecompileJar, type DecompileResult } from "./types";
 import type { Jar } from "../../utils/Jar";
 import type { DecompileWorker } from "./worker";
+import { toClassFilePath, type ClassName } from "../../utils/Names";
 
 function createWorker() {
     const worker = new Worker(new URL("./worker.ts", import.meta.url), { type: "module", name: "decompiler" });
@@ -109,9 +110,8 @@ export function decompileEntireJar(jar: Jar, options?: DecompileEntireJarOptions
     };
 }
 
-export async function decompileClass(className: string, jar: Jar): Promise<DecompileResult> {
-    className = className.replace(".class", "");
-    const entry = jar.entries[`${className}.class`];
+export async function decompileClass(className: ClassName, jar: Jar): Promise<DecompileResult> {
+    const entry = jar.entries[toClassFilePath(className)];
 
     if (!entry) return {
         className,
@@ -125,9 +125,8 @@ export async function decompileClass(className: string, jar: Jar): Promise<Decom
     return await worker.decompile(className, jar.name, jar.blob);
 }
 
-export async function getClassBytecode(className: string, jar: Jar): Promise<DecompileResult> {
-    className = className.replace(".class", "");
-    const entry = jar.entries[`${className}.class`];
+export async function getClassBytecode(className: ClassName, jar: Jar): Promise<DecompileResult> {
+    const entry = jar.entries[toClassFilePath(className)];
 
     if (!entry) return {
         className,
@@ -147,7 +146,7 @@ export async function getClassBytecode(className: string, jar: Jar): Promise<Dec
             continue;
         }
 
-        const data = await jar.entries[`${classFile}.class`].bytes();
+        const data = await jar.entries[toClassFilePath(classFile)]!.bytes();
         classData.push(data.buffer);
     }
 

--- a/src/workers/decompile/types.ts
+++ b/src/workers/decompile/types.ts
@@ -1,8 +1,9 @@
 import type { Token } from "../../logic/Tokens";
 import type { Jar } from "../../utils/Jar";
+import { classNameFromClassFilePath, isClassFilePath, toClassFilePath, type ClassName } from "../../utils/Names";
 
 export type DecompileResult = {
-    className: string;
+    className: ClassName;
     checksum: number;
     source: string;
     tokens: Token[];
@@ -11,12 +12,11 @@ export type DecompileResult = {
 
 export type DecompileOption = { key: string, value: string; };
 
-export type DecompileData = {
-    [className: string]: undefined | {
+export type DecompileData = Partial<Record<ClassName, {
         checksum: number;
         data: Uint8Array | Promise<Uint8Array>;
-    };
-};
+    }>>;
+type DecompileDataEntry = NonNullable<DecompileData[ClassName]>;
 
 export class DecompileJar {
     jar: Jar;
@@ -25,8 +25,8 @@ export class DecompileJar {
     constructor(jar: Jar) {
         this.jar = jar;
         this.proxy = new Proxy({}, {
-            get(_, className: string): DecompileData[""] {
-                const entry = jar.entries[className + ".class"];
+            get(_, className: string): DecompileDataEntry | undefined {
+                const entry = jar.entries[toClassFilePath(className)];
                 if (entry) return {
                     checksum: entry.crc32,
                     data: entry.bytes()
@@ -35,12 +35,12 @@ export class DecompileJar {
         });
     }
 
-    private _classes: string[] | null = null;
+    private _classes: ClassName[] | null = null;
     get classes() {
         if (this._classes) return this._classes;
         this._classes = Object.keys(this.jar.entries)
-            .filter(f => f.endsWith(".class"))
-            .map(f => f.replace(".class", ""))
+            .filter(isClassFilePath)
+            .map(classNameFromClassFilePath)
             .sort();
         return this._classes;
     }

--- a/src/workers/decompile/worker.ts
+++ b/src/workers/decompile/worker.ts
@@ -5,6 +5,7 @@ import type { Token } from "../../logic/Tokens";
 import { type DecompileResult, type DecompileOption, type DecompileData, DecompileJar } from "./types";
 import { openJar } from "../../utils/Jar";
 import { JarIndexer } from "../jar-index/types";
+import { classNameFromDottedClassName, toClassName, type ClassName } from "../../utils/Names";
 
 export class DecompileWorker {
     #lastPromise: Promise<unknown> | undefined = undefined;
@@ -86,7 +87,7 @@ export class DecompileWorker {
     decompileMany = (
         jarName: string,
         jarBlob: Blob,
-        classNames: string[],
+        classNames: ClassName[],
         sab: SharedArrayBuffer,
         splits: number,
         logger?: (index: number) => Promise<void> | void,
@@ -97,8 +98,8 @@ export class DecompileWorker {
         let logPromises: Promise<void>[] = [];
         let nameLogger;
         if (logger) {
-            const class2index = new Map(classNames.map((v, i) => [v, i] as [string, number]));
-            nameLogger = (className: string) => {
+            const class2index = new Map(classNames.map((v, i) => [v, i] as [ClassName, number]));
+            nameLogger = (className: ClassName) => {
                 if (!class2index) return;
                 const i = class2index.get(className);
                 if (i) logPromises.push(Promise.resolve(logger!(i)));
@@ -110,7 +111,7 @@ export class DecompileWorker {
             const i = Atomics.add(state, 0, splits);
             if (i >= classNames.length) break;
 
-            const targetClassNames: string[] = [];
+            const targetClassNames: ClassName[] = [];
             for (let j = 0; j < splits; j++) {
                 if ((i + j) >= classNames.length) break;
 
@@ -145,7 +146,7 @@ export class DecompileWorker {
     });
 
     decompile = (
-        className: string,
+        className: ClassName,
         jarName: string,
         jarBlob: Blob,
     ): Promise<DecompileResult> => this.schedule(async () => {
@@ -170,19 +171,20 @@ export class DecompileWorker {
     });
 
     async #decompile(
-        jarClasses: string[],
-        classNames: string[],
+        jarClasses: ClassName[],
+        classNames: ClassName[],
         classData: DecompileData,
-        logger?: (className: string) => void,
+        logger?: (className: ClassName) => void,
     ): Promise<DecompileResult[]> {
         const allTokens: Record<string, Token[]> = {};
         let currentContent: string | undefined;
         let currentTokens: Token[] | undefined;
-        let currentClassName: string | undefined;
+        let currentClassName: ClassName | undefined;
 
         const sources = await vf.decompile(classNames, {
             source: async (name) => {
-                const data = await classData[name]?.data;
+                const className = toClassName(name);
+                const data = await classData[className]?.data;
 
                 if (!data) {
                     if (name.startsWith("net/minecraft/")) {
@@ -204,7 +206,7 @@ export class DecompileWorker {
                     }
                 },
                 startClass(className) {
-                    currentClassName = className;
+                    currentClassName = toClassName(className);
                 },
                 endClass() {
                     if (logger && currentClassName) logger(currentClassName);
@@ -217,19 +219,19 @@ export class DecompileWorker {
                     currentTokens = [];
                 },
                 visitClass(start, length, declaration, name) {
-                    currentTokens!.push({ type: "class", start, length, className: name, declaration });
+                    currentTokens!.push({ type: "class", start, length, className: toClassName(name), declaration });
                 },
                 visitField(start, length, declaration, className, name, descriptor) {
-                    currentTokens!.push({ type: "field", start, length, className, declaration, name, descriptor });
+                    currentTokens!.push({ type: "field", start, length, className: toClassName(className), declaration, name, descriptor });
                 },
                 visitMethod(start, length, declaration, className, name, descriptor) {
-                    currentTokens!.push({ type: "method", start, length, className, declaration, name, descriptor });
+                    currentTokens!.push({ type: "method", start, length, className: toClassName(className), declaration, name, descriptor });
                 },
                 visitParameter(start, length, declaration, className, _methodName, _methodDescriptor, _index, _name) {
-                    currentTokens!.push({ type: "parameter", start, length, className, declaration });
+                    currentTokens!.push({ type: "parameter", start, length, className: toClassName(className), declaration });
                 },
                 visitLocal(start, length, declaration, className, _methodName, _methodDescriptor, _index, _name) {
-                    currentTokens!.push({ type: "local", start, length, className, declaration });
+                    currentTokens!.push({ type: "local", start, length, className: toClassName(className), declaration });
                 },
                 end() {
                     allTokens[currentContent!] = currentTokens!;
@@ -240,24 +242,25 @@ export class DecompileWorker {
         });
 
         const res: DecompileResult[] = [];
-        for (const [className, source] of Object.entries(sources)) {
+        for (const [rawClassName, source] of Object.entries(sources)) {
+            const className = toClassName(rawClassName);
             const checksum = classData[className]?.checksum ?? 0;
             const tokens = allTokens[source] ?? [];
 
             const importRegex = /^\s*import\s+(?!static\b)([^\s;]+)\s*;/gm;
             let match = null;
             while ((match = importRegex.exec(source)) !== null) {
-                const importPath = match[1].replaceAll('.', '/');
+                const importPath = classNameFromDottedClassName(match[1]);
                 if (importPath.endsWith('*')) {
                     continue;
                 }
 
-                const className = importPath.substring(importPath.lastIndexOf('/') + 1);
+                const simpleClassName = importPath.substring(importPath.lastIndexOf('/') + 1);
 
                 tokens.push({
                     type: "class",
-                    start: match.index + match[0].lastIndexOf(className),
-                    length: importPath.length - importPath.lastIndexOf(className),
+                    start: match.index + match[0].lastIndexOf(simpleClassName),
+                    length: importPath.length - importPath.lastIndexOf(simpleClassName),
                     className: importPath,
                     declaration: false
                 });
@@ -272,7 +275,7 @@ export class DecompileWorker {
     }
 
     #indexer = new JarIndexer();
-    getClassBytecode = (className: string, checksum: number, classData: ArrayBufferLike[]): Promise<DecompileResult> => this.schedule(async () => {
+    getClassBytecode = (className: ClassName, checksum: number, classData: ArrayBufferLike[]): Promise<DecompileResult> => this.schedule(async () => {
         let result = await this.db.results3.get([className, checksum, "bytecode"]);
         if (result) return result;
 

--- a/src/workers/jar-index/client.ts
+++ b/src/workers/jar-index/client.ts
@@ -3,22 +3,23 @@ import { BehaviorSubject, distinctUntilChanged, map, shareReplay } from "rxjs";
 import { minecraftJar, type MinecraftJar } from "../../logic/MinecraftApi";
 import type { ClassDataString, JarIndexer, ReferenceKey, ReferenceString } from "./types";
 import Dexie, { type EntityTable } from "dexie";
+import { isClassFilePath, toClassName, type ClassFilePath, type ClassName } from "../../utils/Names";
 
 
 export interface ClassData {
-    className: string;
-    superName: string;
+    className: ClassName;
+    superName: ClassName | "";
     accessFlags: number;
-    interfaces: string[];
+    interfaces: ClassName[];
 }
 
 export function parseClassData(data: ClassDataString): ClassData {
     const [className, superName, accessFlagsStr, interfacesStr] = data.split("|");
     return {
-        className,
-        superName,
+        className: toClassName(className),
+        superName: superName ? toClassName(superName) : "",
         accessFlags: parseInt(accessFlagsStr, 10),
-        interfaces: interfacesStr ? interfacesStr.split(",").filter(i => i.length > 0) : []
+        interfaces: interfacesStr ? interfacesStr.split(",").filter(i => i.length > 0).map(toClassName) : []
     };
 }
 
@@ -106,11 +107,11 @@ export class JarIndex {
 
             const jar = this.minecraftJar.jar;
             const classNames = Object.keys(jar.entries)
-                .filter(name => name.endsWith(".class"));
+                .filter(isClassFilePath);
 
             let promises: Promise<number>[] = [];
 
-            let taskQueue = [...classNames];
+            let taskQueue: ClassFilePath[] = [...classNames];
             let completed = 0;
 
             for (let i = 0; i < this.workers.length; i++) {

--- a/src/workers/jar-index/types.ts
+++ b/src/workers/jar-index/types.ts
@@ -1,10 +1,11 @@
 import { load } from "../../../java/build/generated/teavm/wasm-gc/java.wasm-runtime.js";
 import indexerWasm from '../../../java/build/generated/teavm/wasm-gc/java.wasm?url';
 import { openJar, type Jar } from "../../utils/Jar.js";
+import type { ClassFilePath, ClassName } from "../../utils/Names.js";
 
-export type Class = string;
-export type Method = `${string}:${string}:${string}`;
-export type Field = `${string}:${string}:${string}`;
+export type Class = ClassName;
+export type Method = `${ClassName}:${string}:${string}`;
+export type Field = `${ClassName}:${string}:${string}`;
 
 // oxlint-disable-next-line typescript/no-redundant-type-constituents
 export type ReferenceKey = Class | Method;
@@ -42,7 +43,7 @@ export class JarIndexer {
         this.#jar = await openJar(name, blob);
     };
 
-    indexBatch = async (classNames: string[]): Promise<void> => {
+    indexBatch = async (classNames: ClassFilePath[]): Promise<void> => {
         if (!this.#jar) {
             throw new Error("Jar not set in worker");
         }
@@ -50,6 +51,9 @@ export class JarIndexer {
         const currentJar = this.#jar; // Capture for closure
         const arrayBufferPromises = classNames.map(async className => {
             const entry = currentJar.entries[className];
+            if (!entry) {
+                throw new Error(`Class entry not found: ${className}`);
+            }
             const data = await entry.blob();
             return data.arrayBuffer();
         });


### PR DESCRIPTION
This makes it impossible to pass a string of "net/minecraft/ChatFormatting" where the function expected "net/minecraft/ChatFormatting.class" or "net.minecraft.ChatFormatting".