### PR TITLE
Search inheritance hierarchy for declarations when navigating

### DIFF
--- a/java/src/main/java/mcsrc/ClassIndexVisitor.java
+++ b/java/src/main/java/mcsrc/ClassIndexVisitor.java
@@ -113,6 +113,7 @@ public class ClassIndexVisitor extends ClassVisitor {
 	}
 
 	public void indexMethod(Entry.Method methodEntry) {
+		Indexer.addMemberData(methodEntry.owner(), methodEntry);
 		indexMethodDescriptor(methodEntry, methodEntry.desc());
 	}
 
@@ -144,6 +145,7 @@ public class ClassIndexVisitor extends ClassVisitor {
 		}
 
 		if (type.getSort() == Type.OBJECT) {
+			Indexer.addMemberData(field.owner(), field);
 			Indexer.addReference(type.getInternalName(), field.reference());
 		}
 	}

--- a/java/src/main/java/mcsrc/ClassIndexVisitor.java
+++ b/java/src/main/java/mcsrc/ClassIndexVisitor.java
@@ -139,13 +139,14 @@ public class ClassIndexVisitor extends ClassVisitor {
 	public void indexField(Entry.Field field) {
 		Type type = Type.getType(field.desc());
 
+		Indexer.addMemberData(field.owner(), field);
+
 		if (type.getSort() == Type.ARRAY) {
 			indexField(new Entry.Field(field.owner(), field.name(), type.getElementType().getDescriptor()));
 			return;
 		}
 
 		if (type.getSort() == Type.OBJECT) {
-			Indexer.addMemberData(field.owner(), field);
 			Indexer.addReference(type.getInternalName(), field.reference());
 		}
 	}

--- a/java/src/main/java/mcsrc/Indexer.java
+++ b/java/src/main/java/mcsrc/Indexer.java
@@ -124,7 +124,7 @@ public class Indexer {
         int accessFlags;
     }
 
-    public static final class ClassMemberInfo implements JSObject {
+    public static final class ClassMemberInfo {
         private final String className;
         private final List<String> methods;
         private final List<String> fields;
@@ -141,18 +141,6 @@ public class Indexer {
 
         public void addField(Entry.Field field) {
             fields.add(field.str());
-        }
-
-        public String getClassName() {
-            return className;
-        }
-
-        public String[] getMethods() {
-            return methods.toArray(new String[0]);
-        }
-
-        public String[] getFields() {
-            return fields.toArray(new String[0]);
         }
     }
 }

--- a/java/src/main/java/mcsrc/Indexer.java
+++ b/java/src/main/java/mcsrc/Indexer.java
@@ -5,6 +5,8 @@ import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.util.Textifier;
 import org.objectweb.asm.util.TraceClassVisitor;
 import org.teavm.jso.JSExport;
+import org.teavm.jso.JSObject;
+import org.teavm.jso.JSProperty;
 import org.teavm.jso.typedarrays.ArrayBuffer;
 import org.teavm.jso.typedarrays.Int8Array;
 
@@ -17,6 +19,7 @@ public class Indexer {
     private static int referenceSize = 0;
     
     private static final Map<String, ClassInheritanceInfo> inheritanceData = new HashMap<>();
+    private static final Map<String, ClassMemberInfo> memberData = new HashMap<>();
 
     @JSExport
     public static void index(ArrayBuffer arrayBuffer) {
@@ -76,6 +79,29 @@ public class Indexer {
         info.interfaces = interfaces != null ? interfaces : new String[0];
         info.accessFlags = accessFlags;
     }
+
+    public static void addMemberData(String className, Entry.Method method) {
+        ClassMemberInfo info = memberData.computeIfAbsent(className, k -> new ClassMemberInfo(className));
+        info.addMethod(method);
+    }
+
+    public static void addMemberData(String className, Entry.Field field) {
+        ClassMemberInfo info = memberData.computeIfAbsent(className, k -> new ClassMemberInfo(className));
+        info.addField(field);
+    }
+
+    @JSExport
+    public static String[] getMemberData() {
+        List<String> result = new ArrayList<>();
+        for (ClassMemberInfo info : memberData.values()) {
+            StringBuilder sb = new StringBuilder();
+            sb.append(info.className).append("|");
+            sb.append(String.join(",", info.methods)).append("|");
+            sb.append(String.join(",", info.fields));
+            result.add(sb.toString());
+        }
+        return result.toArray(new String[0]);
+    }
     
     @JSExport
     public static String[] getClassData() {
@@ -96,5 +122,40 @@ public class Indexer {
         String superName;
         String[] interfaces;
         int accessFlags;
+    }
+
+    public static final class ClassMemberInfo implements JSObject {
+        private final String className;
+        private final List<String> methods;
+        private final List<String> fields;
+
+        public ClassMemberInfo(String className) {
+            this.className = className;
+            this.methods = new ArrayList<>();
+            this.fields = new ArrayList<>();
+        }
+
+        public void addMethod(Entry.Method method) {
+            methods.add(method.str());
+        }
+
+        public void addField(Entry.Field field) {
+            fields.add(field.str());
+        }
+
+        @JSProperty
+        public String getClassName() {
+            return className;
+        }
+
+        @JSProperty
+        public String[] getMethods() {
+            return methods.toArray(new String[0]);
+        }
+
+        @JSProperty
+        public String[] getFields() {
+            return fields.toArray(new String[0]);
+        }
     }
 }

--- a/java/src/main/java/mcsrc/Indexer.java
+++ b/java/src/main/java/mcsrc/Indexer.java
@@ -143,17 +143,14 @@ public class Indexer {
             fields.add(field.str());
         }
 
-        @JSProperty
         public String getClassName() {
             return className;
         }
 
-        @JSProperty
         public String[] getMethods() {
             return methods.toArray(new String[0]);
         }
 
-        @JSProperty
         public String[] getFields() {
             return fields.toArray(new String[0]);
         }

--- a/src/logic/FindDeclaration.ts
+++ b/src/logic/FindDeclaration.ts
@@ -1,0 +1,68 @@
+import {jarIndex} from "../workers/jar-index/client.ts";
+import {firstValueFrom, from, map, switchMap} from "rxjs";
+import type {MemberData} from "../workers/jar-index/types.ts";
+import type {Token} from "./Tokens.ts";
+import {type ClassNode, inheritanceIndex} from "./Inheritance.ts";
+
+const memberDataResults = jarIndex.pipe(
+    switchMap(index => from(parseMemberData(index.getMemberData())))
+);
+
+async function parseMemberData(memberData: Promise<MemberData[]>) {
+    let map = new Map<string, MemberData>();
+    for (let memberDataEntry of await memberData) {
+        map.set(memberDataEntry.className, memberDataEntry);
+    }
+    return map;
+}
+
+function getClassNode(className: string) : Promise<ClassNode> {
+    let classNode = inheritanceIndex.pipe(map(index => index.addClass(className)));
+    return firstValueFrom(classNode);
+}
+
+export async function findDeclaration(token : Token) {
+    if ("descriptor" in token) {
+        const memberData = await firstValueFrom(memberDataResults);
+        let classNode = await getClassNode(token.className);
+        if (classHasMember(memberData, token.className, token.name, token.descriptor, token.type)) {
+            return token.className;
+        }
+        for (let node of getAllAncestors(classNode)) {
+            if (classHasMember(memberData, node.name, token.name, token.descriptor, token.type)) {
+                return node.name;
+            }
+        }
+    }
+    return token.className;
+}
+
+function getAllAncestors(node: ClassNode) : ClassNode[] {
+    const ancestors : ClassNode[] = [];
+    const visited = new Set<ClassNode>();
+
+    function walk(node: ClassNode) {
+        for (const parent of node.parents) {
+            if (visited.has(parent)) continue;
+            visited.add(parent);
+            ancestors.push(parent);
+            walk(parent);
+        }
+    }
+    walk(node);
+    return ancestors;
+}
+
+function classHasMember(memberData: Map<string, MemberData>, className: string, memberName: string, memberDescriptor : string, memberType: "field" | "method") : boolean {
+    let classMemberData = memberData.get(className);
+    if (classMemberData) {
+        let members = memberType === "field" ? classMemberData.fields : classMemberData.methods;
+        for (let member of members) {
+            let parts = member.split(":");
+            if (parts[1] === memberName && parts[2] === memberDescriptor) {
+                return true;
+            }
+        }
+    }
+    return false;
+}

--- a/src/ui/CodeExtensions.ts
+++ b/src/ui/CodeExtensions.ts
@@ -5,6 +5,7 @@ import { getTokenLocation } from '../logic/Tokens';
 import { selectedFile } from "../logic/State";
 import type { DecompileResult } from "../workers/decompile/types";
 import { BehaviorSubject } from "rxjs";
+import { findDeclaration } from "../logic/FindDeclaration.ts";
 
 export type TokenJumpTarget = {
     className: string;
@@ -46,7 +47,7 @@ export function jumpToToken(
         const { line, column } = getTokenLocation(result, token);
         editor.setSelection(new Range(line, column, line, column + token.length));
         editor.revealLineInCenter(line, 0);
-        break;
+        return;
     }
 
     console.warn(`jumpToToken: Target ${targetType} "${target}" not found in ${result.className}`);
@@ -57,7 +58,7 @@ export function createDefinitionProvider(
     classListRef: { current: string[] | undefined; }
 ) {
     return {
-        provideDefinition(model: editor.ITextModel, position: IPosition, token: CancellationToken) {
+        async provideDefinition(model: editor.ITextModel, position: IPosition, token: CancellationToken) {
             const { lineNumber, column } = position;
 
             if (!decompileResultRef.current) {
@@ -83,12 +84,13 @@ export function createDefinitionProvider(
                 }
 
                 if (targetOffset >= token.start && targetOffset <= token.start + token.length) {
-                    const className = token.className + ".class";
-                    const baseClassName = token.className.split('$')[0] + ".class";
+                    const targetClass = await findDeclaration(token);
+
+                    const className = targetClass + ".class";
+                    const baseClassName = targetClass.split('$')[0] + ".class";
                     console.log(`Found token for definition: ${className} at offset ${token.start}`);
 
                     if (classList && (classList.includes(className) || classList.includes(baseClassName))) {
-                        const targetClass = className;
                         const range = new Range(lineNumber, column, lineNumber, column + token.length);
 
                         return {

--- a/src/workers/jar-index/client.ts
+++ b/src/workers/jar-index/client.ts
@@ -1,7 +1,7 @@
 import * as Comlink from "comlink";
 import { BehaviorSubject, distinctUntilChanged, map, shareReplay } from "rxjs";
 import { minecraftJar, type MinecraftJar } from "../../logic/MinecraftApi";
-import type { ClassDataString, JarIndexer, ReferenceKey, ReferenceString } from "./types";
+import type {ClassDataString, JarIndexer, MemberData, ReferenceKey, ReferenceString} from "./types";
 import Dexie, { type EntityTable } from "dexie";
 
 
@@ -161,6 +161,17 @@ export class JarIndex {
         return Promise.all(results).then(arrays => arrays.flat());
     }
 
+    async getMemberData(): Promise<MemberData[]> {
+        await this.indexJar();
+
+        let results: Promise<MemberData[]>[] = [];
+
+        for (const worker of this.workers) {
+            results.push(worker.c.getMemberData());
+        }
+
+        return Promise.all(results).then(arrays => arrays.flat());
+    }
     async getClassData(): Promise<ClassData[]> {
         if (this.classDataCache) {
             return this.classDataCache;

--- a/src/workers/jar-index/types.ts
+++ b/src/workers/jar-index/types.ts
@@ -16,6 +16,12 @@ export type ReferenceString =
 
 export type ClassDataString = `${string}|${string}|${number}|${string}`;
 
+export type MemberData = {
+    className: string;
+    methods: Method[];
+    fields: Field[];
+};
+
 export class JarIndexer {
     #indexerFunc: Indexer | null = null;
     #jar: Jar | null = null;
@@ -80,6 +86,19 @@ export class JarIndexer {
         const indexer = await this.getIndexer();
         return indexer.getClassData();
     };
+
+    getMemberData = async (): Promise<MemberData[]> => {
+        const indexer = await this.getIndexer();
+        const raw = indexer.getMemberData();
+        return raw.map(item => {
+            let parts = item.split("|");
+            return {
+                className: parts[0],
+                methods: parts[1].split(",") as Method[],
+                fields: parts[2].split(",") as Field[]
+            }
+        })
+    };
 }
 
 interface Indexer {
@@ -88,4 +107,5 @@ interface Indexer {
     getReferenceSize(): number;
     getBytecode(classData: ArrayBufferLike[]): string;
     getClassData(): ClassDataString[];
+    getMemberData(): string[];
 }


### PR DESCRIPTION
When navigating via ctrl + click, also search a class's ancestors for the requested declaration so navigating to an inherited field or method works properly

Fixes #130 