### PR TITLE
support unobfuscated pre-classic and classic versions

### DIFF
--- a/src/logic/MinecraftApi.ts
+++ b/src/logic/MinecraftApi.ts
@@ -92,6 +92,8 @@ async function fetchVersions(): Promise<VersionsList> {
     const mojang = await getJson<VersionsList>(VERSIONS_URL);
     const filteredMojangVersions = mojang.versions.filter(v => {
         if (new Date(v.releaseTime).getFullYear() >= 2026) return true;
+        if (v.id === 'c0.0.13a' || v.id === 'c0.0.11a') return true;
+        if (v.id.startsWith('rd-')) return true;
         const match = v.id.match(/^(\d+)\.(\d+)/);
         if (!match) return false;
         const major = parseInt(match[1], 10);


### PR DESCRIPTION
These are the only other unobfuscated versions in Mojang's manifest. Later Classic versions are partially unobfuscated (because of level saving) but there's still a lot of obfuscated code in those so I don't think it's worth adding them.