### PR TITLE
support viewing hierarchy of inner classes

### DIFF
--- a/src/ui/Code.tsx
+++ b/src/ui/Code.tsx
@@ -137,7 +137,7 @@ const Code = () => {
         );
 
         const viewInheritance = monaco.editor.addEditorAction(
-            createViewInheritanceAction(decompileResultRef, messageApi, (value) => selectedInheritanceClassName.next(value))
+            createViewInheritanceAction(decompileResultRef, classListRef, messageApi, (value) => selectedInheritanceClassName.next(value))
         );
 
         const bytecode = setupJavaBytecodeLanguage(monaco);

--- a/src/ui/CodeContextActions.ts
+++ b/src/ui/CodeContextActions.ts
@@ -159,6 +159,7 @@ export function createFindAllReferencesAction(
 
 export function createViewInheritanceAction(
     decompileResultRef: { current: DecompileResult | undefined; },
+    classListRef: { current: string[] | undefined; },
     messageApi: { error: (msg: string) => void; },
     selectedInheritanceClassNameNext: (value: string) => void
 ) {
@@ -173,7 +174,15 @@ export function createViewInheritanceAction(
                 return;
             }
 
-            const className = decompileResultRef.current.className.replace('.class', '');
+            let className;
+
+            const token = findTokenAtPosition(editor, decompileResultRef.current, classListRef.current);
+            if (token && token.declaration && token.type === 'class') {
+                className = token.className;
+            } else {
+                className = decompileResultRef.current.className.replace('.class', '');
+            }
+
             console.log(`Viewing inheritance for ${className}`);
             openInheritanceViewTab(`hierarchy::${className}`);
         }


### PR DESCRIPTION
fixes #90

I made it so if the cursor is over a class declaration, it uses that class for the 'view inheritance hierarchy' option.