### PR TITLE
Gray out the path of classes in search results

### DIFF
--- a/src/ui/SearchResults.tsx
+++ b/src/ui/SearchResults.tsx
@@ -1,10 +1,11 @@
-import { List } from "antd";
+import { List, theme } from "antd";
 import { searchResults } from "../logic/JarFile";
 import { useObservable } from "../utils/UseObservable";
 import { openCodeTab } from "../logic/tabs";
 import { withoutClassExtension, type ClassFilePath } from "../utils/Names";
 
 const SearchResults = () => {
+    const { token } = theme.useToken();
     const results = useObservable(searchResults);
 
     return (
@@ -23,7 +24,10 @@ const SearchResults = () => {
                     onMouseEnter={(e) => e.currentTarget.style.backgroundColor = 'rgba(255, 255, 255, 0.1)'}
                     onMouseLeave={(e) => e.currentTarget.style.backgroundColor = 'transparent'}
                 >
-                    {withoutClassExtension(item)}
+                    {((path) => <>
+                        <span style={{ color: token.colorTextTertiary }}>{path.slice(0, path.lastIndexOf("/") + 1)}</span>
+                        {path.slice(path.lastIndexOf("/") + 1)}
+                    </>)(withoutClassExtension(item))}
                 </List.Item>
             )}
         />


### PR DESCRIPTION
Here's how it looks in both dark and light mode:
<img width="606" height="698" alt="image" src="https://github.com/user-attachments/assets/cb3f9336-9c16-4255-aca3-a602769e1092" />
<img width="623" height="813" alt="image" src="https://github.com/user-attachments/assets/7a54343b-2889-4471-aa8f-ce1bcb303766" />
