### PR TITLE
Change the search button to an icon, only appears when the search box is empty

### DIFF
--- a/src/ui/SideBar.tsx
+++ b/src/ui/SideBar.tsx
@@ -7,18 +7,17 @@ import { isSearching } from "../logic/JarFile";
 import SearchResults from "./SearchResults";
 import ReferenceResults from "./ReferenceResults";
 import { formatReferenceQuery, isViewingReferences } from "../logic/FindAllReferences";
-import { ArrowLeftOutlined } from "@ant-design/icons";
+import { ArrowLeftOutlined, SearchOutlined } from "@ant-design/icons";
 import { focusSearchEvent } from "../logic/Keybinds";
 import { useEffect, useRef } from "react";
 import { searchQuery, referencesQuery } from "../logic/State";
-
-const { Search } = Input;
 
 const SideBar = () => {
     const showReference = useObservable(isViewingReferences);
     const currentReferenceQuery = useObservable(referencesQuery);
     const focusSearch = useObservable(focusSearchEvent);
     const searchRef = useRef<InputRef>(null);
+    const searchQueryValue = useObservable(searchQuery);
 
     useEffect(() => {
         if (focusSearch) {
@@ -54,7 +53,8 @@ const SideBar = () => {
                     </div>
                 </>
             ) : (
-                <Search ref={searchRef} placeholder="Search classes" allowClear onChange={onChange}></Search>
+                <Input ref={searchRef} placeholder="Search classes" allowClear
+                    onChange={onChange} suffix={!searchQueryValue.length ? <SearchOutlined /> : null} />
             )}
             <Divider size="small" />
             <div style={{ flexGrow: 1, overflowY: "auto" }}>


### PR DESCRIPTION
<img width="558" height="380" alt="image" src="https://github.com/user-attachments/assets/6a238420-2dfc-4491-84dc-c06dc7388373" />
<img width="562" height="357" alt="image" src="https://github.com/user-attachments/assets/23de1145-6682-4405-91fb-fe976c71fa7b" />
<img width="558" height="352" alt="image" src="https://github.com/user-attachments/assets/24603ef7-7868-4cb1-b330-6bd7b9bde123" />
<img width="565" height="290" alt="image" src="https://github.com/user-attachments/assets/5c553778-e772-4022-b9f2-7bab857f953c" />
