### PR TITLE
Ensure search results will eventually reflect throttled query

### DIFF
--- a/src/logic/JarFile.ts
+++ b/src/logic/JarFile.ts
@@ -1,4 +1,4 @@
-import { BehaviorSubject, combineLatest, distinct, distinctUntilChanged, map, Observable, switchMap, throttleTime } from 'rxjs';
+import { BehaviorSubject, asyncScheduler, combineLatest, distinct, distinctUntilChanged, map, Observable, switchMap, throttleTime } from 'rxjs';
 import { minecraftJar } from './MinecraftApi';
 import { performSearch } from './Search';
 import { searchQuery } from './State';
@@ -15,7 +15,7 @@ export const classesList = fileList.pipe(
 );
 
 const debouncedSearchQuery: Observable<string> = searchQuery.pipe(
-    throttleTime(200),
+    throttleTime(200, asyncScheduler, { trailing: true }),
     distinctUntilChanged()
 );
 


### PR DESCRIPTION
Currently, throttled keypresses will never update the search results, causing them to be outdated when the user has very quickly entered the query.

Enabling the trailing option ensures that the `throttleTime` will always trigger the last throttled query after the 200ms period has elapsed.