### PR TITLE
Include missing versions in version selector

### DIFF
--- a/src/logic/MinecraftApi.ts
+++ b/src/logic/MinecraftApi.ts
@@ -8,7 +8,7 @@ const CACHE_NAME = 'mcsrc-v1';
 const VERSIONS_URL = "https://piston-meta.mojang.com/mc/game/version_manifest_v2.json";
 
 interface VersionsList {
-    versions: VersionListEntry[];
+    versions: VersionListEntry[]
 }
 
 interface VersionListEntry {
@@ -50,7 +50,6 @@ export interface MinecraftJarMetadata {
 export const minecraftVersions = agreedEula.observable.pipe(
     filter(agreed => agreed),
     switchMap(() => from(fetchVersions())),
-    map(versionsList => versionsList.versions),
     tap(versions => {
         // On inital load, if we dont have a version selected or the selected version is not valid, default to the latest version.
         const currentVersion = selectedMinecraftVersion.value;
@@ -103,15 +102,13 @@ async function getJson<T>(url: string): Promise<T> {
     return response.json();
 }
 
-async function fetchVersions(): Promise<VersionsList> {
+async function fetchVersions(): Promise<VersionListEntry[]> {
     const mojang = await getJson<VersionsList>(VERSIONS_URL);
-    const filteredMojangVersions = mojang.filter(isSupported);
+    const filteredMojangVersions = mojang.versions.filter(isSupported);
     const versions = filteredMojangVersions
-        .concat(EXPERIMENTAL_VERSIONS.versions)
+        .concat(EXPERIMENTAL_VERSIONS)
         .sort((a, b) => b.releaseTime.localeCompare(a.releaseTime));
-    return {
-        versions: versions
-    };
+    return versions;
 }
 
 export function isUnobfuscated(version: VersionListEntry): boolean {
@@ -274,95 +271,93 @@ async function prepareMinecraftJarBlob(
 }
 
 // Hardcode as these are never going to change.
-const EXPERIMENTAL_VERSIONS: VersionsList = {
-    versions: [
-        {
-            id: "25w45a_unobfuscated",
-            type: "unobfuscated",
-            url: "https://maven.fabricmc.net/net/minecraft/25w45a_unobfuscated.json",
-            time: "2025-11-04T14:07:08+00:00",
-            releaseTime: "2025-11-04T14:07:08+00:00",
-            sha1: "7a3c149f148b6aa5ac3af48c4f701adea7e5b615",
-        },
-        {
-            id: "25w46a_unobfuscated",
-            type: "unobfuscated",
-            url: "https://maven.fabricmc.net/net/minecraft/25w46a_unobfuscated.json",
-            time: "2025-11-11T13:20:54+00:00",
-            releaseTime: "2025-11-11T13:20:54+00:00",
-            sha1: "314ade2afeada364047798e163ef8e82427c69e1",
-        },
-        {
-            id: "1.21.11-pre1_unobfuscated",
-            type: "unobfuscated",
-            url: "https://maven.fabricmc.net/net/minecraft/1_21_11-pre1_unobfuscated.json",
-            time: "2025-11-19T08:30:46+00:00",
-            releaseTime: "2025-11-19T08:30:46+00:00",
-            sha1: "9c267f8dda2728bae55201a753cdd07b584709f1",
-        },
-        {
-            id: "1.21.11-pre2_unobfuscated",
-            type: "unobfuscated",
-            url: "https://maven.fabricmc.net/net/minecraft/1_21_11-pre2_unobfuscated.json",
-            time: "2025-11-21T12:07:21+00:00",
-            releaseTime: "2025-11-21T12:07:21+00:00",
-            sha1: "2955ce0af0512fdfe53ff0740b017344acf6f397",
-        },
-        {
-            id: "1.21.11-pre3_unobfuscated",
-            type: "unobfuscated",
-            url: "https://maven.fabricmc.net/net/minecraft/1_21_11-pre3_unobfuscated.json",
-            time: "2025-11-25T14:14:30+00:00",
-            releaseTime: "2025-11-25T14:14:30+00:00",
-            sha1: "579bf3428f72b5ea04883d202e4831bfdcb2aa8d",
-        },
-        {
-            id: "1.21.11-pre4_unobfuscated",
-            type: "unobfuscated",
-            url: "https://maven.fabricmc.net/net/minecraft/1_21_11-pre4_unobfuscated.json",
-            time: "2025-12-01T13:40:12+00:00",
-            releaseTime: "2025-12-01T13:40:12+00:00",
-            sha1: "410ce37a2506adcfd54ef7d89168cfbe89cac4cb",
-        },
-        {
-            id: "1.21.11-pre5_unobfuscated",
-            type: "unobfuscated",
-            url: "https://maven.fabricmc.net/net/minecraft/1_21_11-pre5_unobfuscated.json",
-            time: "2025-12-03T13:34:06+00:00",
-            releaseTime: "2025-12-03T13:34:06+00:00",
-            sha1: "1028441ca6d288bbf2103e773196bf524f7260fd",
-        },
-        {
-            id: "1.21.11-rc1_unobfuscated",
-            type: "unobfuscated",
-            url: "https://maven.fabricmc.net/net/minecraft/1_21_11-rc1_unobfuscated.json",
-            time: "2025-12-04T15:56:55+00:00",
-            releaseTime: "2025-12-04T15:56:55+00:00",
-            sha1: "5d3ee0ef1f0251cf7e073354ca9e085a884a643d",
-        },
-        {
-            id: "1.21.11-rc2_unobfuscated",
-            type: "unobfuscated",
-            url: "https://maven.fabricmc.net/net/minecraft/1_21_11-rc2_unobfuscated.json",
-            time: "2025-12-05T11:57:45+00:00",
-            releaseTime: "2025-12-05T11:57:45+00:00",
-            sha1: "9282a3fb154d2a425086c62c11827281308bf93b",
-        },
-        {
-            id: "1.21.11-rc3_unobfuscated",
-            type: "unobfuscated",
-            url: "https://maven.fabricmc.net/net/minecraft/1_21_11-rc3_unobfuscated.json",
-            time: "2025-12-08T13:59:34+00:00",
-            releaseTime: "2025-12-08T13:59:34+00:00",
-            sha1: "ce3f7ac6d0e9d23ea4e5f0354b91ff15039d9931",
-        },
-        {
-            id: "1.21.11_unobfuscated",
-            type: "unobfuscated",
-            url: "https://maven.fabricmc.net/net/minecraft/1_21_11_unobfuscated.json",
-            time: "2025-12-09T12:43:15+00:00",
-            releaseTime: "2025-12-09T12:43:15+00:00",
-            sha1: "327be7759157b04495c591dbb721875e341877af",
-        }
-    ]
-};
+const EXPERIMENTAL_VERSIONS: VersionListEntry[] = [
+    {
+        id: "25w45a_unobfuscated",
+        type: "unobfuscated",
+        url: "https://maven.fabricmc.net/net/minecraft/25w45a_unobfuscated.json",
+        time: "2025-11-04T14:07:08+00:00",
+        releaseTime: "2025-11-04T14:07:08+00:00",
+        sha1: "7a3c149f148b6aa5ac3af48c4f701adea7e5b615",
+    },
+    {
+        id: "25w46a_unobfuscated",
+        type: "unobfuscated",
+        url: "https://maven.fabricmc.net/net/minecraft/25w46a_unobfuscated.json",
+        time: "2025-11-11T13:20:54+00:00",
+        releaseTime: "2025-11-11T13:20:54+00:00",
+        sha1: "314ade2afeada364047798e163ef8e82427c69e1",
+    },
+    {
+        id: "1.21.11-pre1_unobfuscated",
+        type: "unobfuscated",
+        url: "https://maven.fabricmc.net/net/minecraft/1_21_11-pre1_unobfuscated.json",
+        time: "2025-11-19T08:30:46+00:00",
+        releaseTime: "2025-11-19T08:30:46+00:00",
+        sha1: "9c267f8dda2728bae55201a753cdd07b584709f1",
+    },
+    {
+        id: "1.21.11-pre2_unobfuscated",
+        type: "unobfuscated",
+        url: "https://maven.fabricmc.net/net/minecraft/1_21_11-pre2_unobfuscated.json",
+        time: "2025-11-21T12:07:21+00:00",
+        releaseTime: "2025-11-21T12:07:21+00:00",
+        sha1: "2955ce0af0512fdfe53ff0740b017344acf6f397",
+    },
+    {
+        id: "1.21.11-pre3_unobfuscated",
+        type: "unobfuscated",
+        url: "https://maven.fabricmc.net/net/minecraft/1_21_11-pre3_unobfuscated.json",
+        time: "2025-11-25T14:14:30+00:00",
+        releaseTime: "2025-11-25T14:14:30+00:00",
+        sha1: "579bf3428f72b5ea04883d202e4831bfdcb2aa8d",
+    },
+    {
+        id: "1.21.11-pre4_unobfuscated",
+        type: "unobfuscated",
+        url: "https://maven.fabricmc.net/net/minecraft/1_21_11-pre4_unobfuscated.json",
+        time: "2025-12-01T13:40:12+00:00",
+        releaseTime: "2025-12-01T13:40:12+00:00",
+        sha1: "410ce37a2506adcfd54ef7d89168cfbe89cac4cb",
+    },
+    {
+        id: "1.21.11-pre5_unobfuscated",
+        type: "unobfuscated",
+        url: "https://maven.fabricmc.net/net/minecraft/1_21_11-pre5_unobfuscated.json",
+        time: "2025-12-03T13:34:06+00:00",
+        releaseTime: "2025-12-03T13:34:06+00:00",
+        sha1: "1028441ca6d288bbf2103e773196bf524f7260fd",
+    },
+    {
+        id: "1.21.11-rc1_unobfuscated",
+        type: "unobfuscated",
+        url: "https://maven.fabricmc.net/net/minecraft/1_21_11-rc1_unobfuscated.json",
+        time: "2025-12-04T15:56:55+00:00",
+        releaseTime: "2025-12-04T15:56:55+00:00",
+        sha1: "5d3ee0ef1f0251cf7e073354ca9e085a884a643d",
+    },
+    {
+        id: "1.21.11-rc2_unobfuscated",
+        type: "unobfuscated",
+        url: "https://maven.fabricmc.net/net/minecraft/1_21_11-rc2_unobfuscated.json",
+        time: "2025-12-05T11:57:45+00:00",
+        releaseTime: "2025-12-05T11:57:45+00:00",
+        sha1: "9282a3fb154d2a425086c62c11827281308bf93b",
+    },
+    {
+        id: "1.21.11-rc3_unobfuscated",
+        type: "unobfuscated",
+        url: "https://maven.fabricmc.net/net/minecraft/1_21_11-rc3_unobfuscated.json",
+        time: "2025-12-08T13:59:34+00:00",
+        releaseTime: "2025-12-08T13:59:34+00:00",
+        sha1: "ce3f7ac6d0e9d23ea4e5f0354b91ff15039d9931",
+    },
+    {
+        id: "1.21.11_unobfuscated",
+        type: "unobfuscated",
+        url: "https://maven.fabricmc.net/net/minecraft/1_21_11_unobfuscated.json",
+        time: "2025-12-09T12:43:15+00:00",
+        releaseTime: "2025-12-09T12:43:15+00:00",
+        sha1: "327be7759157b04495c591dbb721875e341877af",
+    }
+];

--- a/src/logic/MinecraftApi.ts
+++ b/src/logic/MinecraftApi.ts
@@ -105,13 +105,7 @@ async function getJson<T>(url: string): Promise<T> {
 
 async function fetchVersions(): Promise<VersionsList> {
     const mojang = await getJson<VersionsList>(VERSIONS_URL);
-    const filteredMojangVersions = mojang.versions.filter(v => {
-        // Any version released after 2026 is deobfuscated
-        if (new Date(v.releaseTime).getFullYear() >= 2026) return true;
-        if (v.id === 'c0.0.13a' || v.id === 'c0.0.11a') return true;
-        if (v.id.startsWith('rd-')) return true;
-        return hasOfficialMappings(v);
-    });
+    const filteredMojangVersions = mojang.filter(isSupported);
     const versions = filteredMojangVersions
         .concat(EXPERIMENTAL_VERSIONS.versions)
         .sort((a, b) => b.releaseTime.localeCompare(a.releaseTime));
@@ -120,28 +114,20 @@ async function fetchVersions(): Promise<VersionsList> {
     };
 }
 
-const RELEASE_PATTERN = /^1\.\d+(\.\d+)?$/;
-const SNAPSHOT_PATTERN = /^\d{2}w\d{2}[a-z]$/;
+export function isUnobfuscated(version: VersionListEntry): boolean {
+        // Any version released after 2025-12-16 is unobfuscated (starting from 26.1-snapshot-1)
+        if (new Date(version.releaseTime) >= new Date(2025, 11, 16)) return true;
+        if (version.id === 'c0.0.13a' || version.id === 'c0.0.11a') return true;
+        if (version.id.startsWith('rd-')) return true;
+        return false;
+}
 
-export function hasOfficialMappings(version: VersionListEntry): boolean {
-    if (version.type === "release" && RELEASE_PATTERN.test(version.id)) {
-        const match = version.id.match(/^1\.(\d+)(?:\.(\d+))?$/);
-        if (!match) return false;
-
-        const minor = parseInt(match[1], 10);
-        const patch = match[2] ? parseInt(match[2], 10) : 0;
-        return minor > 14 || (minor === 14 && patch >= 4);
-    }
-
-    if (version.type === "snapshot" && SNAPSHOT_PATTERN.test(version.id)) {
-        const match = version.id.match(/^(\d{2})w(\d{2})[a-z]$/);
-        if (!match) return false;
-
-        const year = parseInt(match[1], 10) + 2000;
-        const week = parseInt(match[2], 10);
-        return year > 2019 || (year === 2019 && week >= 36);
-    }
-
+function isSupported(version: VersionListEntry): boolean {
+    if(isUnobfuscated(version)) return true;
+    // Versions starting from 19w36a (released on 2019-09-04) have official mappings available
+    if (new Date(version.releaseTime) >= new Date(2019, 8, 4)) return true;
+    // Official mappings were backported to 1.14.4
+    if (version.id === "1.14.4") return true;
     return false;
 }
 

--- a/src/logic/MinecraftApi.ts
+++ b/src/logic/MinecraftApi.ts
@@ -112,17 +112,19 @@ async function fetchVersions(): Promise<VersionListEntry[]> {
 }
 
 export function isUnobfuscated(version: VersionListEntry): boolean {
-        // Any version released after 2025-12-16 is unobfuscated (starting from 26.1-snapshot-1)
-        if (new Date(version.releaseTime) >= new Date(2025, 11, 16)) return true;
-        if (version.id === 'c0.0.13a' || version.id === 'c0.0.11a') return true;
-        if (version.id.startsWith('rd-')) return true;
-        return false;
+    // Not present in the official manifest, but used by entries in EXPERIMENTAL_VERSIONS
+    if (version.type === 'unobfuscated') return true;
+    // Any version released after 2025-12-16 is unobfuscated (starting from 26.1-snapshot-1)
+    if (new Date(version.releaseTime) >= new Date("2025-12-16")) return true;
+    if (version.id === 'c0.0.13a' || version.id === 'c0.0.11a') return true;
+    if (version.id.startsWith('rd-')) return true;
+    return false;
 }
 
 function isSupported(version: VersionListEntry): boolean {
     if(isUnobfuscated(version)) return true;
     // Versions starting from 19w36a (released on 2019-09-04) have official mappings available
-    if (new Date(version.releaseTime) >= new Date(2019, 8, 4)) return true;
+    if (new Date(version.releaseTime) >= new Date("2019-09-04")) return true;
     // Official mappings were backported to 1.14.4
     if (version.id === "1.14.4") return true;
     return false;

--- a/src/logic/Permalink.ts
+++ b/src/logic/Permalink.ts
@@ -2,7 +2,7 @@ import { combineLatest } from "rxjs";
 import { resetPermalinkAffectingSettings, supportsPermalinking } from "./Settings";
 import { diffLeftSelectedMinecraftVersion, diffView, selectedFile, selectedLines, selectedMinecraftVersion } from "./State";
 import { toClassFilePath, withoutClassExtension, type ClassFilePath } from "../utils/Names";
-import { hasOfficialMappings, minecraftVersions } from "./MinecraftApi";
+import { isUnobfuscated, minecraftVersions } from "./MinecraftApi";
 
 export interface State {
     version: number; // Allows us to change the permalink structure in the future
@@ -141,7 +141,7 @@ if (typeof window !== "undefined") {
             }
 
             const versionEntry = minecraftVersions.find(v => v.id === minecraftVersion);
-            if (versionEntry && hasOfficialMappings(versionEntry)) {
+            if (versionEntry && !isUnobfuscated(versionEntry)) {
                 supported = false;
             }
 


### PR DESCRIPTION
Includes 26.1-snapshot-1, as well as the `-pre` and `-rc` obfuscated versions.

instead of parsing the version, we now just check the release date with a few exceptions.