### PR TITLE
Add 'Copy Mixin Target' action to non mc functions

### DIFF
--- a/src/ui/Code.tsx
+++ b/src/ui/Code.tsx
@@ -15,9 +15,10 @@ import { IS_JAVADOC_EDITOR } from '../site';
 import { applyJavadocCodeExtensions } from '../javadoc/JavadocCodeExtensions';
 import { selectedInheritanceClassName } from '../logic/Inheritance';
 import { createHoverProvider } from './CodeHoverProvider';
-import { findTokenAtPosition } from './CodeUtils';
+import { isDefinitionAtPosition } from './CodeUtils';
 import {
     IS_DEFINITION_CONTEXT_KEY_NAME,
+    IS_MC_DEFINITION_CONTEXT_KEY_NAME,
     createCopyAwAction,
     createCopyAtAction,
     createCopyMixinAction,
@@ -375,10 +376,11 @@ const Code = () => {
                     // Update context key when cursor position changes
                     // We use this to know when to show the options to copy AW/Mixin strings
                     const isDefinitionContextKey = codeEditor.createContextKey<boolean>(IS_DEFINITION_CONTEXT_KEY_NAME, false);
+                    const isMcDefinitionContextKey = codeEditor.createContextKey<boolean>(IS_MC_DEFINITION_CONTEXT_KEY_NAME, false);
                     codeEditor.onDidChangeCursorPosition((e) => {
-                        const token = findTokenAtPosition(codeEditor, decompileResultRef.current, classListRef.current);
-                        const validToken = token != null && (token.type == "class" || token.type == "method" || token.type == "field");
-                        isDefinitionContextKey.set(validToken);
+                        const { normal, minecraft } = isDefinitionAtPosition(codeEditor, decompileResultRef.current, classListRef.current);
+                        isDefinitionContextKey.set(normal);
+                        isMcDefinitionContextKey.set(minecraft);
                     });
                 }} />
         </Spin>

--- a/src/ui/Code.tsx
+++ b/src/ui/Code.tsx
@@ -378,9 +378,9 @@ const Code = () => {
                     const isDefinitionContextKey = codeEditor.createContextKey<boolean>(IS_DEFINITION_CONTEXT_KEY_NAME, false);
                     const isMcDefinitionContextKey = codeEditor.createContextKey<boolean>(IS_MC_DEFINITION_CONTEXT_KEY_NAME, false);
                     codeEditor.onDidChangeCursorPosition((e) => {
-                        const { normal, minecraft } = isDefinitionAtPosition(codeEditor, decompileResultRef.current, classListRef.current);
-                        isDefinitionContextKey.set(normal);
-                        isMcDefinitionContextKey.set(minecraft);
+                        const definition = isDefinitionAtPosition(codeEditor, decompileResultRef.current, classListRef.current);
+                        isDefinitionContextKey.set(definition != null);
+                        isMcDefinitionContextKey.set(definition == "minecraft");
                     });
                 }} />
         </Spin>

--- a/src/ui/CodeContextActions.ts
+++ b/src/ui/CodeContextActions.ts
@@ -6,6 +6,7 @@ import { dottedClassNameFromClassName, type ClassFilePath, type ClassName } from
 import type { ReferenceKey } from "../workers/jar-index/types";
 
 export const IS_DEFINITION_CONTEXT_KEY_NAME = "is_definition";
+export const IS_MC_DEFINITION_CONTEXT_KEY_NAME = "is_mc_definition";
 
 async function setClipboard(text: string): Promise<void> {
     await navigator.clipboard.writeText(text);
@@ -20,7 +21,7 @@ export function createCopyAwAction(
         id: 'copy_aw',
         label: 'Copy Class Tweaker / Access Widener',
         contextMenuGroupId: '9_cutcopypaste',
-        precondition: IS_DEFINITION_CONTEXT_KEY_NAME,
+        precondition: IS_MC_DEFINITION_CONTEXT_KEY_NAME,
         run: async function (editor: editor.ICodeEditor, ...args: any[]): Promise<void> {
             const token = findTokenAtPosition(editor, decompileResultRef.current, classListRef.current);
             if (!token) {
@@ -57,7 +58,7 @@ export function createCopyAtAction(
         id: 'copy_at',
         label: 'Copy Access Transformer',
         contextMenuGroupId: '9_cutcopypaste',
-        precondition: IS_DEFINITION_CONTEXT_KEY_NAME,
+        precondition: IS_MC_DEFINITION_CONTEXT_KEY_NAME,
         run: async function (editor: editor.ICodeEditor, ...args: any[]): Promise<void> {
             const token = findTokenAtPosition(editor, decompileResultRef.current, classListRef.current);
             if (!token) {
@@ -96,7 +97,7 @@ export function createCopyMixinAction(
         contextMenuGroupId: '9_cutcopypaste',
         precondition: IS_DEFINITION_CONTEXT_KEY_NAME,
         run: async function (editor: editor.ICodeEditor, ...args: any[]): Promise<void> {
-            const token = findTokenAtPosition(editor, decompileResultRef.current, classListRef.current);
+            const token = findTokenAtPosition(editor, decompileResultRef.current, classListRef.current, false);
             if (!token) {
                 messageApi.error("Failed to find token for Mixin target.");
                 return;
@@ -135,7 +136,7 @@ export function createFindAllReferencesAction(
         contextMenuOrder: 1,
         precondition: IS_DEFINITION_CONTEXT_KEY_NAME,
         run: async function (editor: editor.ICodeEditor, ...args: any[]): Promise<void> {
-            const token = findTokenAtPosition(editor, decompileResultRef.current, classListRef.current);
+            const token = findTokenAtPosition(editor, decompileResultRef.current, classListRef.current, false);
             if (!token) {
                 messageApi.error("Failed to find token for references.");
                 return;

--- a/src/ui/CodeUtils.ts
+++ b/src/ui/CodeUtils.ts
@@ -2,6 +2,8 @@ import { editor } from "monaco-editor";
 import { type Token } from '../logic/Tokens';
 import { toClassFilePath, type ClassFilePath } from "../utils/Names";
 
+export type DefinitionType = "generic" | "minecraft";
+
 function getTargetOffset(editor: editor.ICodeEditor): number | null {
     const model = editor.getModel();
     if (!model) {
@@ -57,10 +59,10 @@ export function isDefinitionAtPosition(
     editor: editor.ICodeEditor,
     decompileResult: { tokens: Token[]; },
     classList: ClassFilePath[]
-): { normal: boolean, minecraft: boolean } {
+): DefinitionType | null {
     const targetOffset = getTargetOffset(editor);
     if (!targetOffset) {
-        return { normal: false, minecraft: false };
+        return null;
     }
 
     let found: boolean = false;
@@ -75,11 +77,11 @@ export function isDefinitionAtPosition(
             found = true;
             const className = toClassFilePath(token.className.split('$')[0]);
             if (classList.includes(className)) {
-                return { normal: true, minecraft: true };
+                return "minecraft";
             }
         }
     }
 
-    return { normal: found, minecraft: false };
+    return found ? "generic" : null;
 }
 

--- a/src/ui/CodeUtils.ts
+++ b/src/ui/CodeUtils.ts
@@ -2,14 +2,9 @@ import { editor } from "monaco-editor";
 import { type Token } from '../logic/Tokens';
 import { toClassFilePath, type ClassFilePath } from "../utils/Names";
 
-export function findTokenAtPosition(
-    editor: editor.ICodeEditor,
-    decompileResult: { tokens: Token[]; } | undefined,
-    classList: ClassFilePath[] | undefined,
-    useClassList = true
-): Token | null {
+function getTargetOffset(editor: editor.ICodeEditor): number | null {
     const model = editor.getModel();
-    if (!model || !decompileResult || (useClassList && !classList)) {
+    if (!model) {
         return null;
     }
 
@@ -21,12 +16,26 @@ export function findTokenAtPosition(
     const { lineNumber, column } = position;
     const lines = model.getLinesContent();
     let charCount = 0;
-    let targetOffset = 0;
 
     for (let i = 0; i < lineNumber - 1; i++) {
         charCount += lines[i].length + 1; // +1 for \n
     }
-    targetOffset = charCount + (column - 1);
+    return charCount + (column - 1);
+}
+
+export function findTokenAtPosition(
+    editor: editor.ICodeEditor,
+    decompileResult: { tokens: Token[]; } | undefined,
+    classList: ClassFilePath[] | undefined,
+    useClassList = true
+): Token | null {
+    if (!decompileResult || (useClassList && !classList)) {
+        return null;
+    }
+    const targetOffset = getTargetOffset(editor);
+    if (!targetOffset) {
+        return null;
+    }
 
     for (const token of decompileResult.tokens) {
         if (targetOffset >= token.start && targetOffset <= token.start + token.length) {
@@ -43,3 +52,34 @@ export function findTokenAtPosition(
 
     return null;
 }
+
+export function isDefinitionAtPosition(
+    editor: editor.ICodeEditor,
+    decompileResult: { tokens: Token[]; },
+    classList: ClassFilePath[]
+): { normal: boolean, minecraft: boolean } {
+    const targetOffset = getTargetOffset(editor);
+    if (!targetOffset) {
+        return { normal: false, minecraft: false };
+    }
+
+    let found: boolean = false;
+
+    for (const token of decompileResult.tokens) {
+        if (token.start > targetOffset) {
+            break;
+        }
+
+        const isDef = token.type == "class" || token.type == "method" || token.type == "field";
+        if (isDef && targetOffset <= token.start + token.length) {
+            found = true;
+            const className = toClassFilePath(token.className.split('$')[0]);
+            if (classList.includes(className)) {
+                return { normal: true, minecraft: true };
+            }
+        }
+    }
+
+    return { normal: found, minecraft: false };
+}
+


### PR DESCRIPTION
added separate context key for minecraft classes specifically so that access widening shows up only for mc while mixin target can be copied for anything

also find references shows up for non mc things now.