### PR TITLE
Forget oldest tab history entry, instead of newest

### DIFF
--- a/src/logic/tabs/Tabs.ts
+++ b/src/logic/tabs/Tabs.ts
@@ -51,10 +51,11 @@ export abstract class Tab {
     protected onBlur() { };
 
     protected pushToTabHistory() {
-        if (tabHistory.value.length < 50) {
-            // Limit history to 50
-            tabHistory.next([...tabHistory.value, this.key]);
-        }
+        // Limit history to 50, forgetting older entries
+        const entriesToForget = tabHistory.value.length < 50 ? 0 : 1;
+        const newHistory = tabHistory.value.slice(entriesToForget);
+        newHistory.push(this.key);
+        tabHistory.next(newHistory);
     }
 
     protected removeFromTabHistory() {

--- a/src/logic/tabs/Tabs.ts
+++ b/src/logic/tabs/Tabs.ts
@@ -69,8 +69,10 @@ export abstract class Tab {
         // Get the last tab
         let tab = openTabs.value.find(t => t.key === lastTabKeyFromHistory);
 
-        // If no tab can be found in the tab history, we simply default to the first open one
-        if (!tab) tab = openTabs.value[0];
+        // If no tab can be found in the tab history, we simply default to the last open one
+        if (!tab && openTabs.value.length > 0) {
+            tab = openTabs.value[openTabs.value.length - 1];
+        }
         tab?.open();
     }
 
@@ -117,8 +119,11 @@ export const openInheritanceViewTab = (key: string) => openTabOfType(key, Inheri
 
 export const closeTab = (key: string) => {
     const tab = openTabs.value.find(o => o.key === key);
+    const wasOpen = openTab.value?.key === key;
     tab?.onClose();
-    tab?.openLastTabFromHistory();
+    if (wasOpen) {
+        tab?.openLastTabFromHistory();
+    }
 };
 
 export const setTabPosition = (key: string, placeIndex: number) => {


### PR DESCRIPTION
Currently, when the tab history hits 50 entries, new entries stop being added entirely. This means that if you open more than 50 tabs and then close one, focus jumps to whatever arbitrary tab was the 50th. Since loading the most recent history entry happens when *any* tab is closed, not just the active one, the tab you close doesn't even have to be the one that's open. This continues to happen until the history has been reduced to under 50 entries, making navigation very annoying.

Improvements in this PR:

* Forget the oldest tab history entry when history is full, instead of blocking new entries from being added. This way, loading the latest history entry can only fail if the user opens more than 50 tabs and then closes the most recent 50 without opening any new ones.
* Only load the latest history entry when the active tab is closed, instead of unconditionally. This prevents unnecessary flickering when a background tab is closed, and fixes the active tab changing because a background tab was closed if the history is exhausted as described above.
* As a minor taste change, if history is exhausted and the active tab is closed, open the rightmost tab instead of the leftmost tab. In general I would assume that the rightmost tab was opened more recently than the leftmost.