### PR TITLE
Line selection in diff mode and copying permalinks to a specific line

### DIFF
--- a/src/logic/Permalink.test.ts
+++ b/src/logic/Permalink.test.ts
@@ -74,7 +74,7 @@ describe('Permalink', () => {
             });
         });
 
-        describe('Line Number Parsing', () => {
+        describe('Normal Mod Line Number Parsing', () => {
             it('should parse single line number with #', () => {
                 const state = parsePathToState('1/1.21/net/minecraft/ChatFormatting#L123')!;
 
@@ -123,6 +123,26 @@ describe('Permalink', () => {
 
             it('should return null selectedLines when no line number present', () => {
                 const state = parsePathToState('1/1.21/net/minecraft/ChatFormatting')!;
+                expect(state.selectedLines).toBe(null);
+            });
+
+            it('should return null selectedLines when line number is malformed', () => {
+                const state = parsePathToState('1/1.21/net/minecraft/ChatFormatting#Labc')!;
+                expect(state.selectedLines).toBe(null);
+            });
+
+            it('should return null selectedLines when line number is not at the end', () => {
+                const state = parsePathToState('1/1.21/net/minecraft/ChatFormatting#L5something')!;
+                expect(state.selectedLines).toBe(null);
+            });
+
+            it('should return null selectedLines when using #R', () => {
+                const state = parsePathToState('1/1.21/net/minecraft/ChatFormatting#R12')!;
+                expect(state.selectedLines).toBe(null);
+            });
+
+            it('should return null selectedLines when using #LR', () => {
+                const state = parsePathToState('1/1.21/net/minecraft/ChatFormatting#LR12')!;
                 expect(state.selectedLines).toBe(null);
             });
         });
@@ -211,6 +231,122 @@ describe('Permalink', () => {
             });
         });
 
+        describe('Diff Mode Line Number Parsing', () => {
+            it('should parse single line number with #L', () => {
+                const state = parsePathToState('1/diff/1.21/1.21.4/net/minecraft/ChatFormatting#L123')!;
+
+                expect(state.selectedLines).toEqual({
+                    line: 123,
+                    lineEnd: undefined
+                });
+                expect(state.diff).toEqual({ leftMinecraftVersion: '1.21', selectionSide: 'left' });
+            });
+
+            it('should parse line range with #L', () => {
+                const state = parsePathToState('1/diff/1.21/1.21.4/net/minecraft/ChatFormatting#L10-20')!;
+
+                expect(state.selectedLines).toEqual({
+                    line: 10,
+                    lineEnd: 20
+                });
+                expect(state.diff).toEqual({ leftMinecraftVersion: '1.21', selectionSide: 'left' });
+            });
+
+            it('should parse single line number with #R', () => {
+                const state = parsePathToState('1/diff/1.21/1.21.4/net/minecraft/ChatFormatting#R123')!;
+
+                expect(state.selectedLines).toEqual({
+                    line: 123,
+                    lineEnd: undefined
+                });
+                expect(state.diff).toEqual({ leftMinecraftVersion: '1.21', selectionSide: 'right' });
+            });
+
+            it('should parse line range with #R', () => {
+                const state = parsePathToState('1/diff/1.21/1.21.4/net/minecraft/ChatFormatting#R10-20')!;
+
+                expect(state.selectedLines).toEqual({
+                    line: 10,
+                    lineEnd: 20
+                });
+                expect(state.diff).toEqual({ leftMinecraftVersion: '1.21', selectionSide: 'right' });
+            });
+
+            it('should handle URL-encoded line marker (%23) with L', () => {
+                const state = parsePathToState('1/diff/1.21/1.21.4/net/minecraft/ChatFormatting%23L50')!;
+
+                expect(state.selectedLines).toEqual({
+                    line: 50,
+                    lineEnd: undefined
+                });
+                expect(state.diff).toEqual({ leftMinecraftVersion: '1.21', selectionSide: 'left' });
+            });
+
+            it('should handle URL-encoded line marker (%23) with R', () => {
+                const state = parsePathToState('1/diff/1.21/1.21.4/net/minecraft/ChatFormatting%23R50')!;
+
+                expect(state.selectedLines).toEqual({
+                    line: 50,
+                    lineEnd: undefined
+                });
+                expect(state.diff).toEqual({ leftMinecraftVersion: '1.21', selectionSide: 'right' });
+            });
+
+            it('should handle URL-encoded line range (%23) with L', () => {
+                const state = parsePathToState('1/diff/1.21/1.21.4/net/minecraft/ChatFormatting%23L10-20')!;
+
+                expect(state.selectedLines).toEqual({
+                    line: 10,
+                    lineEnd: 20
+                });
+                expect(state.diff).toEqual({ leftMinecraftVersion: '1.21', selectionSide: 'left' });
+            });
+
+            it('should handle URL-encoded line range (%23) with R', () => {
+                const state = parsePathToState('1/diff/1.21/1.21.4/net/minecraft/ChatFormatting%23R10-20')!;
+
+                expect(state.selectedLines).toEqual({
+                    line: 10,
+                    lineEnd: 20
+                });
+                expect(state.diff).toEqual({ leftMinecraftVersion: '1.21', selectionSide: 'right' });
+            });
+
+            it('should handle line number at end of complex path', () => {
+                const state = parsePathToState('1/diff/1.21/1.21.4/net/minecraft/ChatFormatting/ChatFormatting#L123')!;
+
+                expect(state.selectedLines).toEqual({
+                    line: 123,
+                    lineEnd: undefined
+                });
+                expect(state.diff).toEqual({ leftMinecraftVersion: '1.21', selectionSide: 'left' });
+            });
+
+            it('should return null selectedLines when no line number present', () => {
+                const state = parsePathToState('1/diff/1.21/1.21.4/net/minecraft/ChatFormatting')!;
+                expect(state.selectedLines).toBe(null);
+                expect(state.diff!.selectionSide).toBeUndefined();
+            });
+
+            it('should return null selectedLines when line number is malformed', () => {
+                const state = parsePathToState('1/diff/1.21/1.21.4/net/minecraft/ChatFormatting#Labc')!;
+                expect(state.selectedLines).toBe(null);
+                expect(state.diff!.selectionSide).toBeUndefined();
+            });
+
+            it('should return null selectedLines when line number is not at the end', () => {
+                const state = parsePathToState('1/diff/1.21/1.21.4/net/minecraft/ChatFormatting#L5something')!;
+                expect(state.selectedLines).toBe(null);
+                expect(state.diff!.selectionSide).toBeUndefined();
+            });
+
+            it('should return null selectedLines when using #LR', () => {
+                const state = parsePathToState('1/diff/1.21/1.21.4/net/minecraft/ChatFormatting#LR12')!;
+                expect(state.selectedLines).toBe(null);
+                expect(state.diff!.selectionSide).toBeUndefined();
+            });
+        });
+
         describe('Real-world Examples', () => {
             it('should parse multiline permalink', () => {
                 const state = parsePathToState('1/1.21.4/net/minecraft/server/MinecraftServer#L250-260')!;
@@ -225,12 +361,16 @@ describe('Permalink', () => {
             });
 
             it('should parse a real-world diff permalink', () => {
-                const state = parsePathToState('1/diff/1.21.4/1.21.5/net/minecraft/server/MinecraftServer')!;
+                const state = parsePathToState('1/diff/1.21.4/1.21.5/net/minecraft/server/MinecraftServer#R250-260')!;
 
                 expect(state.version).toBe(1);
                 expect(state.minecraftVersion).toBe('1.21.5');
                 expect(state.file).toBe('net/minecraft/server/MinecraftServer.class');
-                expect(state.diff).toEqual({ leftMinecraftVersion: '1.21.4' });
+                expect(state.diff).toEqual({ leftMinecraftVersion: '1.21.4', selectionSide: 'right' });
+                expect(state.selectedLines).toEqual({
+                    line: 250,
+                    lineEnd: 260
+                });
             });
         });
     });

--- a/src/logic/Permalink.ts
+++ b/src/logic/Permalink.ts
@@ -1,6 +1,6 @@
 import { combineLatest } from "rxjs";
 import { resetPermalinkAffectingSettings, supportsPermalinking } from "./Settings";
-import { diffLeftSelectedMinecraftVersion, diffView, selectedFile, selectedLines, selectedMinecraftVersion } from "./State";
+import { diffLeftSelectedMinecraftVersion, diffSelectionSide, diffView, selectedFile, selectedLines, selectedMinecraftVersion } from "./State";
 import { toClassFilePath, withoutClassExtension, type ClassFilePath } from "../utils/Names";
 
 export interface State {
@@ -13,6 +13,7 @@ export interface State {
     } | null;
     diff?: {
         leftMinecraftVersion: string;
+        selectionSide?: 'left' | 'right'; // if it's undefined, default to right
     };
 }
 
@@ -24,14 +25,23 @@ const DEFAULT_STATE: State = {
 };
 
 export const parsePathToState = (path: string): State | null => {
-    // Check for line number marker (e.g., #L123 or #L10-20)
+    // Check for line number marker (e.g., #L123 or #L10-20, or #R123)
+    // In normal mode L stands for line
+    // In diff mode L stands for left, R stands for right
+    // L & R cannot be mixed
     let lineNumber: number | null = null;
     let lineEnd: number | null = null;
-    const lineMatch = path.match(/(?:#|%23)L(\d+)(?:-(\d+))?$/);
+    let diffSide: 'left' | 'right' | undefined = undefined;
+    const lineMatch = path.match(/(?:#|%23)([LR])(\d+)(?:-(\d+))?$/);
     if (lineMatch) {
-        lineNumber = parseInt(lineMatch[1], 10);
-        if (lineMatch[2]) {
-            lineEnd = parseInt(lineMatch[2], 10);
+        if (!lineMatch[1] || !lineMatch[2]) {
+            return null;
+        }
+
+        diffSide = lineMatch[1] === 'L' ? 'left' : 'right';
+        lineNumber = parseInt(lineMatch[2], 10);
+        if (lineMatch[3]) {
+            lineEnd = parseInt(lineMatch[3], 10);
         }
         path = path.substring(0, lineMatch.index);
     }
@@ -55,8 +65,8 @@ export const parsePathToState = (path: string): State | null => {
             version,
             minecraftVersion: rightMinecraftVersion,
             file: filePath ? toClassFilePath(filePath) : undefined,
-            selectedLines: null,
-            diff: { leftMinecraftVersion }
+            selectedLines: lineNumber ? { line: lineNumber, lineEnd: lineEnd || undefined } : null,
+            diff: { leftMinecraftVersion, selectionSide: diffSide }
         };
     }
 
@@ -66,6 +76,12 @@ export const parsePathToState = (path: string): State | null => {
     // Backwards compatibility with the incorrect version name used previously
     if (minecraftVersion == "25w45a") {
         minecraftVersion = "25w45a_unobfuscated";
+    }
+
+    // #R not available in normal mode
+    if (diffSide === 'right') {
+        lineNumber = null;
+        lineEnd = null;
     }
 
     return {
@@ -88,7 +104,7 @@ export const getInitialState = (): State => {
         : (hash.startsWith('#/') ? hash.slice(2) : (hash.startsWith('#') ? hash.slice(1) : ''));
 
     // For new style (pathname-based), append hash if it contains line number
-    if (newStyle && hash.startsWith('#L')) {
+    if (newStyle && (hash.startsWith('#L') || hash.startsWith('#R'))) {
         path += hash;
     }
 
@@ -114,14 +130,16 @@ if (typeof window !== "undefined") {
             selectedFile,
             selectedLines,
             supportsPermalinking,
-            diffView
+            diffView,
+            diffSelectionSide
         ]).subscribe(([
             minecraftVersion,
             diffLeftMinecraftVersion,
             file,
             selectedLines,
             supported,
-            diffView
+            diffView,
+            diffSelectionSide
         ]) => {
             if (!file && !diffView) {
                 document.title = "mcsrc.dev";
@@ -149,6 +167,17 @@ if (typeof window !== "undefined") {
                 url += `diff/${diffLeftMinecraftVersion}/${minecraftVersion}`;
                 if (file) {
                     url += `/${withoutClassExtension(file)}`;
+                }
+
+                if (selectedLines) {
+                    const side = diffSelectionSide === 'left' ? 'L' : 'R';
+
+                    const { line, lineEnd } = selectedLines;
+                    if (lineEnd && lineEnd !== line) {
+                        url += `#${side}${Math.min(line, lineEnd)}-${Math.max(line, lineEnd)}`;
+                    } else {
+                        url += `#${side}${line}`;
+                    }
                 }
             } else {
                 url += `${minecraftVersion}/${withoutClassExtension(file!)}`;

--- a/src/logic/State.ts
+++ b/src/logic/State.ts
@@ -28,6 +28,13 @@ export const selectedLines = new BehaviorSubject<SelectedLines | null>(initialSt
 
 export const diffView = new BehaviorSubject<boolean>(!!initialState.diff);
 export const diffLeftSelectedMinecraftVersion = new BehaviorSubject<string | null>(initialState.diff?.leftMinecraftVersion ?? null);
+export const diffSelectionSide = new BehaviorSubject<'left' | 'right' | null>(initialState.diff?.selectionSide ?? null);
+
+export function swapDiffSelectionSideIfPresent() {
+    if (diffSelectionSide.value) {
+        diffSelectionSide.next(diffSelectionSide.value === 'left' ? 'right' : 'left');
+    }
+}
 
 // Reset selected lines when file changes (skip initial emission to preserve permalink selection)
 selectedFile.pipe(pairwise()).subscribe(([previousFile, currentFile]) => {

--- a/src/ui/Code.tsx
+++ b/src/ui/Code.tsx
@@ -56,6 +56,7 @@ const Code = () => {
     const lineHighlightRef = useRef<editor.IEditorDecorationsCollection | null>(null);
     const decompileResultRef = useRef(decompileResult);
     const classListRef = useRef(classList);
+    const selectedLineRef = useRef(selectedLine);
 
     const [messageApi, contextHolder] = message.useMessage();
 
@@ -314,6 +315,10 @@ const Code = () => {
 
     // Handle gutter clicks for line linking
     useEffect(() => {
+        selectedLineRef.current = selectedLine;
+    }, [selectedLine]);
+
+    useEffect(() => {
         if (!editorRef.current) return;
         const codeEditor = editorRef.current;
 
@@ -324,9 +329,9 @@ const Code = () => {
 
                 if (lineNumber) {
                     // Shift-click to select a range
-                    console.log(selectedLine);
-                    if (e.event.shiftKey && selectedLine) {
-                        selectedLines.next({ line: selectedLine.line, lineEnd: lineNumber });
+                    console.log(selectedLineRef.current);
+                    if (e.event.shiftKey && selectedLineRef.current) {
+                        selectedLines.next({ line: selectedLineRef.current.line, lineEnd: lineNumber });
                     } else {
                         selectedLines.next({ line: lineNumber });
                     }
@@ -338,7 +343,7 @@ const Code = () => {
             onMouseDown.dispose();
         };
         // oxlint-disable-next-line eslint-plugin-react-hooks/exhaustive-deps
-    }, [editorRef.current, selectedLine]);
+    }, [editorRef.current, selectedLines]);
 
     return (
         <Spin

--- a/src/ui/Code.tsx
+++ b/src/ui/Code.tsx
@@ -22,7 +22,8 @@ import {
     createCopyAtAction,
     createCopyMixinAction,
     createFindAllReferencesAction,
-    createViewInheritanceAction
+    createViewInheritanceAction,
+    createCopyPermalinkAction
 } from './CodeContextActions';
 import {
     clearTokenJump,
@@ -118,6 +119,8 @@ const Code = () => {
             createFoldingRangeProvider(monaco)
         );
 
+        const copyLink = monaco.editor.addEditorAction(createCopyPermalinkAction(messageApi));
+
         const copyAw = monaco.editor.addEditorAction(
             createCopyAwAction(decompileResultRef, classListRef, messageApi)
         );
@@ -151,6 +154,7 @@ const Code = () => {
             copyMixin.dispose();
             copyAt.dispose();
             copyAw.dispose();
+            copyLink.dispose();
             foldingRange.dispose();
             editorOpener.dispose();
             hoverProvider.dispose();

--- a/src/ui/Code.tsx
+++ b/src/ui/Code.tsx
@@ -185,7 +185,6 @@ const Code = () => {
                 const currentLine = selectedLine?.line;
                 if (currentLine) {
                     const lineEnd = selectedLine?.lineEnd ?? currentLine;
-                    editor.setSelection(new Range(currentLine, 1, currentLine, 1));
                     editor.revealLinesInCenterIfOutsideViewport(currentLine, lineEnd);
 
                     // Highlight the line range
@@ -372,6 +371,7 @@ const Code = () => {
                     foldingHighlight: false,
                     scrollBeyondLastLine: false,
                     editContext: IS_ANDROID_CHROME ? false : undefined, // Disable content editable on Android Chrome to attempt to stop the virtual keyboard from appearing
+                    selectOnLineNumbers: false // To avoid blue flash when selecting lines
                 }}
                 onMount={(codeEditor) => {
                     editorRef.current = codeEditor;

--- a/src/ui/CodeContextActions.ts
+++ b/src/ui/CodeContextActions.ts
@@ -11,6 +11,29 @@ async function setClipboard(text: string): Promise<void> {
     await navigator.clipboard.writeText(text);
 }
 
+export function createCopyPermalinkAction(
+    messageApi: { error: (msg: string) => void; success: (msg: string) => void; }
+) {
+    return {
+        id: 'copy_permalink',
+        label: 'Copy Permalink',
+        contextMenuGroupId: '9_cutcopypaste',
+        run: async function (editor: editor.ICodeEditor, ...args: any[]): Promise<void> {
+            const position = editor.getPosition();
+            if (!position) {
+                messageApi.error("Failed to get cursor position.");
+                return;
+            }
+
+            const urlWithoutHash = window.location.origin + window.location.pathname + window.location.search;
+
+            await setClipboard(urlWithoutHash + "#L" + position.lineNumber);
+
+            messageApi.success("Copied Permalink to clipboard.");
+        }
+    };
+}
+
 export function createCopyAwAction(
     decompileResultRef: { current: DecompileResult | undefined; },
     classListRef: { current: ClassFilePath[] | undefined; },

--- a/src/ui/CodeContextActions.ts
+++ b/src/ui/CodeContextActions.ts
@@ -4,6 +4,8 @@ import type { DecompileResult } from "../workers/decompile/types";
 import { openInheritanceViewTab } from "../logic/tabs";
 import { dottedClassNameFromClassName, type ClassFilePath, type ClassName } from "../utils/Names";
 import type { ReferenceKey } from "../workers/jar-index/types";
+import { supportsPermalinking } from "../logic/Settings";
+import { firstValueFrom } from "rxjs";
 
 export const IS_DEFINITION_CONTEXT_KEY_NAME = "is_definition";
 
@@ -22,6 +24,11 @@ export function createCopyPermalinkAction(
             const position = editor.getPosition();
             if (!position) {
                 messageApi.error("Failed to get cursor position.");
+                return;
+            }
+
+            if (!await firstValueFrom(supportsPermalinking)) {
+                messageApi.error("Permalinks are not supported in this environment.");
                 return;
             }
 

--- a/src/ui/diff/DiffCode.tsx
+++ b/src/ui/diff/DiffCode.tsx
@@ -25,6 +25,9 @@ const DiffCode = () => {
     const rightResult = useObservable(getRightDiff().result);
     const editorRef = useRef<editor.IStandaloneDiffEditor | null>(null);
     const [diffEditor, setDiffEditor] = useState<editor.IStandaloneDiffEditor | null>(null);
+    const [originalEditor, setOriginalEditor] = useState<editor.IStandaloneCodeEditor | null>(null);
+    const [modifiedEditor, setModifiedEditor] = useState<editor.IStandaloneCodeEditor | null>(null);
+    const [editorsReady, setEditorsReady] = useState(false);
     const loading = useObservable(isDecompiling);
     const currentPath = useObservable(selectedFile);
     const isUnified = useObservable(unifiedDiff.observable);
@@ -42,8 +45,25 @@ const DiffCode = () => {
 
     const monaco = useMonaco();
 
-    function getActiveSelectionEditor(editor: editor.IStandaloneDiffEditor) {
-        return selectionSide === "left" ? editor.getOriginalEditor() : editor.getModifiedEditor();
+    function handleOnEditorMount(editor: editor.IStandaloneDiffEditor) {
+        const checkEditors = () => {
+            const original = editor.getOriginalEditor();
+            const modified = editor.getModifiedEditor();
+            if (original && modified) {
+                setOriginalEditor(original);
+                setModifiedEditor(modified);
+                setEditorsReady(true);
+
+                return true;
+            }
+            return false;
+        };
+
+        const interval = setInterval(() => {
+            if (checkEditors()) {
+                clearInterval(interval);
+            }
+        }, 100);
     }
 
     useEffect(() => {
@@ -91,6 +111,10 @@ const DiffCode = () => {
             const editor = editorRef.current;
             lineHighlightRef.current?.clear();
 
+            const getActiveSelectionEditor = (editor: editor.IStandaloneDiffEditor) => {
+                return selectionSide === "left" ? editor.getOriginalEditor() : editor.getModifiedEditor();
+            }
+
             const executeScroll = () => {
                 const currentLine = selectedLine?.line;
                 if (currentLine) {
@@ -114,7 +138,7 @@ const DiffCode = () => {
                 executeScroll();
             });
         }
-    }, [leftResult, rightResult, selectedLine]);
+    }, [leftResult, rightResult, selectedLine, selectionSide]);
 
     // Handle gutter clicks for line linking
     useEffect(() => {
@@ -122,10 +146,10 @@ const DiffCode = () => {
     }, [selectedLine]);
 
     useEffect(() => {
-        if (!editorRef.current?.getOriginalEditor() || !editorRef.current?.getModifiedEditor()) return;
+        if (!originalEditor || !modifiedEditor) return;
 
         const onMouseDownEvents =
-            [editorRef.current?.getOriginalEditor(), editorRef.current?.getModifiedEditor()].map((codeEditor, index) => {
+            [originalEditor, modifiedEditor].map((codeEditor, index) => {
                 return codeEditor.onMouseDown((e) => {
                     if (e.target.type === editor.MouseTargetType.GUTTER_LINE_NUMBERS ||
                         e.target.type === editor.MouseTargetType.GUTTER_GLYPH_MARGIN) {
@@ -149,13 +173,14 @@ const DiffCode = () => {
         return () => {
             onMouseDownEvents.forEach(event => event.dispose());
         };
-    }, [editorRef.current?.getOriginalEditor(), editorRef.current?.getModifiedEditor(), selectedLines, diffSelectionSide]);
+    }, [editorsReady, originalEditor, modifiedEditor]);
 
     // Left line selection in the unified mode is not supported
     // If the user tries to the line in the unified mode or entering with a line hash URL, fall back to side-by-side
     // If the user tries to switch to unified mode while left line is selected, cancel the selection
     useEffect(() => {
-        if (!unifiedDiff.value || !selectedLine?.line || !selectionSide) return;
+        if (!isUnified || !unifiedDiff.value) return; // To avoid observable updating latency
+        if (!selectedLine?.line || !selectionSide || !selectionSide) return;
 
         if (Date.now() - lastLineSelectionTime.current < 500 || Date.now() - loadTime.current < 500) {
             unifiedDiff.value = false;
@@ -164,7 +189,7 @@ const DiffCode = () => {
             diffSelectionSide.next(null);
         }
         messageApi.warning("Left line selection is not supported in unified mode.");
-    }, [unifiedDiff.value, selectedLine?.line, selectionSide, messageApi]);
+    }, [isUnified, selectedLine?.line, selectionSide, messageApi]);
 
     return (
         <Spin
@@ -193,6 +218,8 @@ const DiffCode = () => {
                 onMount={(editor) => {
                     editorRef.current = editor;
                     setDiffEditor(editor);
+
+                    handleOnEditorMount(editor);
                 }}
                 options={{
                     readOnly: true,

--- a/src/ui/diff/DiffCode.tsx
+++ b/src/ui/diff/DiffCode.tsx
@@ -17,6 +17,7 @@ import {
     type DiffDirection
 } from './DiffNavigation';
 import { classNameFromClassFilePath } from '../../utils/Names';
+import { createCopyPermalinkAction } from './DiffCodeContextActions.ts';
 
 const IS_ANDROID_CHROME = /Android/.test(navigator.userAgent) && /Chrome/.test(navigator.userAgent);
 
@@ -70,6 +71,13 @@ const DiffCode = () => {
         if (!monaco) return;
         monaco.editor.setTheme(darkMode ? "vs-dark" : "vs");
     }, [monaco, darkMode]);
+
+    useEffect(() => {
+        if (!originalEditor || !modifiedEditor) return;
+
+        originalEditor.addAction(createCopyPermalinkAction(messageApi, "left"));
+        modifiedEditor.addAction(createCopyPermalinkAction(messageApi, "right"));
+    }, [originalEditor, modifiedEditor]);
 
     useEffect(() => {
         if (loading) return;

--- a/src/ui/diff/DiffCode.tsx
+++ b/src/ui/diff/DiffCode.tsx
@@ -180,7 +180,7 @@ const DiffCode = () => {
     // If the user tries to switch to unified mode while left line is selected, cancel the selection
     useEffect(() => {
         if (!isUnified || !unifiedDiff.value) return; // To avoid observable updating latency
-        if (!selectedLine?.line || !selectionSide || !selectionSide) return;
+        if (!selectedLine?.line || !selectionSide || !selectionSide || selectionSide === 'right') return;
 
         if (Date.now() - lastLineSelectionTime.current < 500 || Date.now() - loadTime.current < 500) {
             unifiedDiff.value = false;

--- a/src/ui/diff/DiffCode.tsx
+++ b/src/ui/diff/DiffCode.tsx
@@ -75,8 +75,14 @@ const DiffCode = () => {
     useEffect(() => {
         if (!originalEditor || !modifiedEditor) return;
 
-        originalEditor.addAction(createCopyPermalinkAction(messageApi, "left"));
-        modifiedEditor.addAction(createCopyPermalinkAction(messageApi, "right"));
+        const originalEditorCopyLink = originalEditor.addAction(createCopyPermalinkAction(messageApi, "left"));
+        const modifiedEditorCopyLink = modifiedEditor.addAction(createCopyPermalinkAction(messageApi, "right"));
+
+        return () => {
+            // Dispose in the oppsite order
+            modifiedEditorCopyLink.dispose();
+            originalEditorCopyLink.dispose();
+        };
     }, [originalEditor, modifiedEditor]);
 
     useEffect(() => {

--- a/src/ui/diff/DiffCode.tsx
+++ b/src/ui/diff/DiffCode.tsx
@@ -3,12 +3,12 @@ import { useObservable } from '../../utils/UseObservable';
 import { getLeftDiff, getRightDiff } from '../../logic/Diff';
 import { updateLineChanges } from '../../logic/LineChanges';
 import { useEffect, useRef, useState } from 'react';
-import type { editor } from 'monaco-editor';
-import { Spin } from "antd";
+import { editor, Range } from 'monaco-editor';
+import { message, Spin } from "antd";
 import { LoadingOutlined } from '@ant-design/icons';
 import { isDecompiling } from "../../logic/Decompiler.ts";
 import { unifiedDiff } from '../../logic/Settings';
-import { selectedFile } from '../../logic/State.ts';
+import { selectedFile, selectedLines, diffSelectionSide } from '../../logic/State.ts';
 import { isDarkMode } from '../../logic/Browser';
 import {
     jumpToCurrentFileEdge,
@@ -29,7 +29,22 @@ const DiffCode = () => {
     const currentPath = useObservable(selectedFile);
     const isUnified = useObservable(unifiedDiff.observable);
     const darkMode = useObservable(isDarkMode);
+
+    const selectedLine = useObservable(selectedLines);
+    const selectionSide = useObservable(diffSelectionSide);
+    const lineHighlightRef = useRef<editor.IEditorDecorationsCollection | null>(null);
+    const selectedLineRef = useRef(selectedLine);
+    const lastLineSelectionTime = useRef(0);
+
+    const loadTime = useRef(Date.now());
+
+    const [messageApi, contextHolder] = message.useMessage();
+
     const monaco = useMonaco();
+
+    function getActiveSelectionEditor(editor: editor.IStandaloneDiffEditor) {
+        return selectionSide === "left" ? editor.getOriginalEditor() : editor.getModifiedEditor();
+    }
 
     useEffect(() => {
         if (!monaco) return;
@@ -70,6 +85,87 @@ const DiffCode = () => {
         };
     }, [diffEditor]);
 
+    // Scroll to top when source changes, or to specific line if specified
+    useEffect(() => {
+        if (editorRef.current && leftResult && rightResult) {
+            const editor = editorRef.current;
+            lineHighlightRef.current?.clear();
+
+            const executeScroll = () => {
+                const currentLine = selectedLine?.line;
+                if (currentLine) {
+                    const lineEnd = selectedLine?.lineEnd ?? currentLine;
+                    getActiveSelectionEditor(editor).revealLinesInCenterIfOutsideViewport(currentLine, lineEnd);
+
+                    // Highlight the line range
+                    lineHighlightRef.current = getActiveSelectionEditor(editor).createDecorationsCollection([{
+                        range: new Range(currentLine, 1, lineEnd, 1),
+                        options: {
+                            isWholeLine: true,
+                            className: 'highlighted-line',
+                            glyphMarginClassName: 'highlighted-line-glyph'
+                        }
+                    }]);
+                }
+            };
+
+            // Use requestAnimationFrame to ensure Monaco has finished layout
+            requestAnimationFrame(() => {
+                executeScroll();
+            });
+        }
+    }, [leftResult, rightResult, selectedLine]);
+
+    // Handle gutter clicks for line linking
+    useEffect(() => {
+        selectedLineRef.current = selectedLine;
+    }, [selectedLine]);
+
+    useEffect(() => {
+        if (!editorRef.current?.getOriginalEditor() || !editorRef.current?.getModifiedEditor()) return;
+
+        const onMouseDownEvents =
+            [editorRef.current?.getOriginalEditor(), editorRef.current?.getModifiedEditor()].map((codeEditor, index) => {
+                return codeEditor.onMouseDown((e) => {
+                    if (e.target.type === editor.MouseTargetType.GUTTER_LINE_NUMBERS ||
+                        e.target.type === editor.MouseTargetType.GUTTER_GLYPH_MARGIN) {
+                        const lineNumber = e.target.position?.lineNumber;
+
+                        if (lineNumber) {
+                            // Shift-click to select a range
+                            if (e.event.shiftKey && selectedLineRef.current) {
+                                selectedLines.next({ line: selectedLineRef.current.line, lineEnd: lineNumber });
+                            } else {
+                                selectedLines.next({ line: lineNumber });
+                            }
+                            diffSelectionSide.next(index === 0 ? 'left' : 'right');
+
+                            lastLineSelectionTime.current = Date.now();
+                        }
+                    }
+                });
+            });
+
+        return () => {
+            onMouseDownEvents.forEach(event => event.dispose());
+        };
+    }, [editorRef.current?.getOriginalEditor(), editorRef.current?.getModifiedEditor(), selectedLines, diffSelectionSide]);
+
+    // Left line selection in the unified mode is not supported
+    // If the user tries to the line in the unified mode or entering with a line hash URL, fall back to side-by-side
+    // If the user tries to switch to unified mode while left line is selected, cancel the selection
+    useEffect(() => {
+        if (!unifiedDiff.value || !selectedLine?.line || !selectionSide) return;
+
+        if (Date.now() - lastLineSelectionTime.current < 500 || Date.now() - loadTime.current < 500) {
+            unifiedDiff.value = false;
+        } else {
+            selectedLines.next(null);
+            diffSelectionSide.next(null);
+        }
+        messageApi.warning("Left line selection is not supported in unified mode.");
+    }, [unifiedDiff.value, selectedLine?.line, selectionSide, messageApi]);
+
     return (
         <Spin
             indicator={<LoadingOutlined spin />}
@@ -86,6 +182,7 @@ const DiffCode = () => {
                 }
             }}
         >
+            {contextHolder}
             <DiffEditor
                 language="java"
                 theme={darkMode ? "vs-dark" : "vs"}
@@ -104,6 +201,7 @@ const DiffCode = () => {
                     useInlineViewWhenSpaceIsLimited: false,
                     scrollBeyondLastLine: false,
                     editContext: IS_ANDROID_CHROME ? false : undefined,
+                    selectOnLineNumbers: false // To avoid blue flash when selecting lines
                     //tabSize: 3,
                 }} />
         </Spin>

--- a/src/ui/diff/DiffCode.tsx
+++ b/src/ui/diff/DiffCode.tsx
@@ -83,7 +83,7 @@ const DiffCode = () => {
             modifiedEditorCopyLink.dispose();
             originalEditorCopyLink.dispose();
         };
-    }, [originalEditor, modifiedEditor]);
+    }, [originalEditor, modifiedEditor, messageApi]);
 
     useEffect(() => {
         if (loading) return;

--- a/src/ui/diff/DiffCodeContextActions.ts
+++ b/src/ui/diff/DiffCodeContextActions.ts
@@ -1,0 +1,33 @@
+import type { editor } from "monaco-editor";
+
+async function setClipboard(text: string): Promise<void> {
+    await navigator.clipboard.writeText(text);
+}
+
+export function createCopyPermalinkAction(
+    messageApi: { error: (msg: string) => void; success: (msg: string) => void; },
+    editorSide: "left" | "right"
+) {
+    return {
+        id: 'copy_permalink',
+        label: 'Copy Permalink',
+        contextMenuGroupId: '9_cutcopypaste',
+        run: async function (editor: editor.ICodeEditor, ...args: any[]): Promise<void> {
+            const position = editor.getPosition();
+            if (!position) {
+                messageApi.error("Failed to get cursor position.");
+                return;
+            }
+
+            const urlWithoutHash = window.location.origin + window.location.pathname + window.location.search;
+
+            if (editorSide === "left") {
+                await setClipboard(urlWithoutHash + "#L" + position.lineNumber);
+            } else {
+                await setClipboard(urlWithoutHash + "#R" + position.lineNumber);
+            }
+
+            messageApi.success("Copied Permalink to clipboard.");
+        }
+    };
+}

--- a/src/ui/diff/DiffCodeContextActions.ts
+++ b/src/ui/diff/DiffCodeContextActions.ts
@@ -1,4 +1,6 @@
 import type { editor } from "monaco-editor";
+import { supportsPermalinking } from "../../logic/Settings";
+import { firstValueFrom } from "rxjs";
 
 async function setClipboard(text: string): Promise<void> {
     await navigator.clipboard.writeText(text);
@@ -16,6 +18,11 @@ export function createCopyPermalinkAction(
             const position = editor.getPosition();
             if (!position) {
                 messageApi.error("Failed to get cursor position.");
+                return;
+            }
+
+            if (!await firstValueFrom(supportsPermalinking)) {
+                messageApi.error("Permalinks are not supported in this environment.");
                 return;
             }
 

--- a/src/ui/diff/DiffVersionSelection.tsx
+++ b/src/ui/diff/DiffVersionSelection.tsx
@@ -2,6 +2,7 @@ import { Flex, Button, Tooltip } from "antd";
 import { SwapOutlined } from "@ant-design/icons";
 import { getLeftDiff, getRightDiff } from "../../logic/Diff";
 import VersionSelector from "../VersionSelector";
+import { swapDiffSelectionSideIfPresent } from "../../logic/State";
 
 const DiffVersionSelection = () => {
     return (
@@ -16,6 +17,8 @@ const DiffVersionSelection = () => {
                         const right = getRightDiff().selectedVersion.getValue();
                         getLeftDiff().selectedVersion.next(right);
                         getRightDiff().selectedVersion.next(left);
+
+                        swapDiffSelectionSideIfPresent();
                     }}
                 />
             </Tooltip>

--- a/tests/copy.spec.ts
+++ b/tests/copy.spec.ts
@@ -38,7 +38,7 @@ test.describe('Copy Actions in Code Context Actions', () => {
     });
 
     for (const { name, successMessage, copyText } of testOptions) {
-        test(name, async ({ page }) => {
+        test(name + ' (normal mode)', async ({ page }) => {
             await page.goto('/1/26.1-mock-2/net/minecraft/ChatFormatting');
             await waitForDecompiledContent(page, 'enum ChatFormatting');
 
@@ -53,4 +53,21 @@ test.describe('Copy Actions in Code Context Actions', () => {
             expect(clipboardText).toEqual(copyText.replace('$(server_origin)', (new URL(page.url())).origin));
         });
     }
+
+    test('Copy Permalink (diff mode)', async ({ page }) => {
+        await page.goto('/1/diff/26.1-mock-1/26.1-mock-2/net/minecraft/client/renderer/LevelRenderer');
+        await waitForDecompiledContent(page, 'class LevelRenderer');
+
+        await page.getByRole('code').getByText('LevelRenderer').first().click({ button: 'right' });
+        // Use anyway. Maybe the hook needs some time.
+        await page.waitForTimeout(50);
+        await page.getByRole('menuitem', { name: 'Copy Permalink' }).click();
+
+        await expect(page.getByText('Copied Permalink')).toBeVisible();
+
+        const clipboardText = await page.evaluate(() => (window as any).__clipboardText);
+        const expected = '$(server_origin)/1/diff/26.1-mock-1/26.1-mock-2/net/minecraft/client/renderer/LevelRenderer#L3'
+            .replace('$(server_origin)', (new URL(page.url())).origin);
+        expect(clipboardText).toEqual(expected);
+    });
 });

--- a/tests/copy.spec.ts
+++ b/tests/copy.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test';
+import { waitForDecompiledContent, setupTest } from './test-utils';
+
+test.describe('Copy Actions in Code Context Actions', () => {
+    const testOptions = [
+        {
+            name: 'Copy Access Transformer',
+            successMessage: 'Copied Access Transformer',
+            copyText: 'public net.minecraft.ChatFormatting',
+        },
+        {
+            name: 'Copy Class Tweaker / Access Widener',
+            successMessage: 'Copied Class Tweaker',
+            copyText: 'accessible class net/minecraft/ChatFormatting',
+        },
+        {
+            name: 'Copy Mixin Target',
+            successMessage: 'Copied Mixin Target',
+            copyText: 'net/minecraft/ChatFormatting',
+        },
+        {
+            name: 'Copy Permalink',
+            successMessage: 'Copied Permalink',
+            copyText: '$(server_origin)/1/26.1-mock-2/net/minecraft/ChatFormatting#L3',
+        }
+        // Monaco native copy is jumped due to its own copy implementation
+    ];
+
+    test.beforeEach(async ({ page }) => {
+        await setupTest(page);
+
+        // Mock the clipboard API
+        await page.addInitScript(() => {
+            navigator.clipboard.writeText = async (test: string) => {
+                (window as any).__clipboardText = test;
+            };
+        });
+    });
+
+    for (const { name, successMessage, copyText } of testOptions) {
+        test(name, async ({ page }) => {
+            await page.goto('/1/26.1-mock-2/net/minecraft/ChatFormatting');
+            await waitForDecompiledContent(page, 'enum ChatFormatting');
+
+            page.getByRole('code').getByText('ChatFormatting').click({ button: 'right' });
+
+            await expect(page.getByRole('menuitem', { name: name })).toBeVisible();
+            page.getByRole('menuitem', { name: name }).click();
+
+            await expect(page.getByText(successMessage)).toBeVisible();
+
+            const clipboardText = await page.evaluate(() => (window as any).__clipboardText);
+            expect(clipboardText).toEqual(copyText.replace('$(server_origin)', (new URL(page.url())).origin));
+        });
+    }
+});

--- a/tests/copy.spec.ts
+++ b/tests/copy.spec.ts
@@ -42,10 +42,10 @@ test.describe('Copy Actions in Code Context Actions', () => {
             await page.goto('/1/26.1-mock-2/net/minecraft/ChatFormatting');
             await waitForDecompiledContent(page, 'enum ChatFormatting');
 
-            page.getByRole('code').getByText('ChatFormatting').click({ button: 'right' });
-
-            await expect(page.getByRole('menuitem', { name: name })).toBeVisible();
-            page.getByRole('menuitem', { name: name }).click();
+            await page.getByRole('code').getByText('ChatFormatting').click({ button: 'right' });
+            // Use anyway. Maybe the hook needs some time.
+            await page.waitForTimeout(50);
+            await page.getByRole('menuitem', { name: name }).click();
 
             await expect(page.getByText(successMessage)).toBeVisible();
 

--- a/tests/permalink.spec.ts
+++ b/tests/permalink.spec.ts
@@ -6,7 +6,7 @@ test.describe('Permalinks and Line Highlighting', () => {
         await setupTest(page);
     });
 
-    test('Permalink with line range highlights multiple lines (new format)', async ({ page }) => {
+    test('Permalink with line range highlights multiple lines (new format, normal mode)', async ({ page }) => {
         await page.goto('/1/26.1-snapshot-1/net/minecraft/SystemReport#L87-90');
 
         await waitForDecompiledContent(page, 'class SystemReport');
@@ -16,10 +16,30 @@ test.describe('Permalinks and Line Highlighting', () => {
         await expect(highlightedLines.first()).toBeVisible();
     });
 
-    test('Permalink with line range highlights multiple lines (old hash format)', async ({ page }) => {
+    test('Permalink with line range highlights multiple lines (new format, diff mode)', async ({ page }) => {
+        await page.goto('/1/diff/26.1-mock-1/26.1-mock-2/net/minecraft/client/renderer/LevelRenderer#R87-90');
+
+        await waitForDecompiledContent(page, 'class LevelRenderer');
+
+        const editor = page.locator('.monaco-editor');
+        const highlightedLines = editor.locator('.highlighted-line');
+        await expect(highlightedLines.first()).toBeVisible();
+    });
+
+    test('Permalink with line range highlights multiple lines (old hash format, normal mode)', async ({ page }) => {
         await page.goto('/#1/26.1-snapshot-1/net/minecraft/SystemReport#L87-90');
 
         await waitForDecompiledContent(page, 'class SystemReport');
+
+        const editor = page.locator('.monaco-editor');
+        const highlightedLines = editor.locator('.highlighted-line');
+        await expect(highlightedLines.first()).toBeVisible();
+    });
+
+    test('Permalink with line range highlights multiple lines (old hash format, diff mode)', async ({ page }) => {
+        await page.goto('/#1/diff/26.1-mock-1/26.1-mock-2/net/minecraft/client/renderer/LevelRenderer#R87-90');
+
+        await waitForDecompiledContent(page, 'class LevelRenderer');
 
         const editor = page.locator('.monaco-editor');
         const highlightedLines = editor.locator('.highlighted-line');
@@ -33,7 +53,7 @@ test.describe('Permalinks and Line Highlighting', () => {
         await expect(versionSelect).toContainText('26.1-mock-2');
     });
 
-    test('Shift-clicking line number creates line range', async ({ page }) => {
+    test('Shift-clicking line number creates line range (normal mode)', async ({ page }) => {
         await page.goto('/');
         await page.getByText('ChatFormatting', { exact: true }).click();
         await waitForDecompiledContent(page, 'enum ChatFormatting');
@@ -58,6 +78,40 @@ test.describe('Permalinks and Line Highlighting', () => {
 
         // Check that URL now contains a line range (new path-based format)
         expect(page.url()).toMatch(/\/1\/.*#L\d+-\d+$/);
+        expect(page.url()).not.toEqual(urlAfterFirstClick);
+
+        // Check that lines are highlighted
+        const highlightedLine = editor.locator('.highlighted-line');
+        await expect(highlightedLine.first()).toBeVisible();
+    });
+
+    test('Shift-clicking line number creates line range (diff mode)', async ({ page }) => {
+        await page.goto('/1/diff/26.1-mock-1/26.1-mock-2/net/minecraft/client/renderer/LevelRenderer');
+
+        // 0 - diff editor, 1 - left editor, 2 - right editor
+        const editor = page.locator('.monaco-editor').nth(2);
+        await expect(editor).toBeVisible();
+
+        // First click to select starting line
+        const lineNumbers = editor.locator('.line-numbers');
+        // I have no idea why there's a 0px div with class line-numbers, only in webkit & firefox
+        // Which will cause infinite waiting on click
+        // So we use nth(1), which is the acutal line 1
+        await lineNumbers.nth(1).click();
+
+        // Wait for URL to update
+        await page.waitForTimeout(10);
+        const urlAfterFirstClick = page.url();
+        expect(urlAfterFirstClick).toMatch(/\/1\/diff\/.*#R\d+$/);
+
+        // Shift-click on a different line to create range
+        await lineNumbers.nth(5).click({ modifiers: ['Shift'] });
+
+        // Wait for URL to update
+        await page.waitForTimeout(10);
+
+        // Check that URL now contains a line range (new path-based format)
+        expect(page.url()).toMatch(/\/1\/diff\/.*#R\d+-\d+$/);
         expect(page.url()).not.toEqual(urlAfterFirstClick);
 
         // Check that lines are highlighted


### PR DESCRIPTION
*Note
1. Left line selection in the unified mode is not supported,
if the user tries to the line in the unified mode or entering with a line hash URL, it will fall back to side-by-side.
if the user tries to switch to unified mode while left line is selected, it will cancel the selection.

2. In diff mod, #L stands for left editor, #R stands for right editor.
3. Permalink state is changed with backward compatibility

fix #120