### PR TITLE
Add advanced settings tab

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -118,6 +118,18 @@ html, body, #root {
     height: 100%;
 }
 
+.settings-tab-content {
+  padding: 16px 12px 4px;
+}
+
+.settings-form .ant-form-item {
+  margin-bottom: 16px;
+}
+
+.settings-form .ant-form-item:last-child {
+  margin-bottom: 0;
+}
+
 .diff-shell {
   height: 100%;
   min-height: 0;

--- a/src/ui/Header.tsx
+++ b/src/ui/Header.tsx
@@ -1,7 +1,6 @@
 import { Button, Divider, Flex, Tooltip } from "antd";
 import { SwapOutlined } from "@ant-design/icons";
 import { SettingsModalButton } from "./SettingsModal";
-import { JarDecompilerModalButton } from "./JarDecompilerModal";
 import VersionSelector from "./VersionSelector";
 import { diffView } from "../logic/State";
 
@@ -32,9 +31,6 @@ const HeaderBody = () => {
                     Compare
                 </Button>
             </Tooltip>
-            <div style={{ flex: "0 0 auto" }}>
-                <JarDecompilerModalButton />
-            </div>
             <div style={{ flex: "0 0 auto" }}>
                 <SettingsModalButton />
             </div>

--- a/src/ui/JarDecompilerModal.tsx
+++ b/src/ui/JarDecompilerModal.tsx
@@ -1,5 +1,4 @@
 import { Alert, Button, Flex, Form, message, Modal, Popconfirm, Progress } from "antd";
-import { JavaOutlined } from '@ant-design/icons';
 import { BehaviorSubject } from "rxjs";
 import { useObservable } from "../utils/UseObservable";
 import { BooleanOption, NumberOption } from "./SettingsModal";
@@ -8,13 +7,7 @@ import { getDecompilerOptions } from "../logic/Decompiler";
 import { decompileEntireJar, deleteCache, setOptions, type DecompileEntireJarTask } from "../workers/decompile/client";
 import { minecraftJar } from "../logic/MinecraftApi";
 
-const modalOpen = new BehaviorSubject(false);
-
-export const JarDecompilerModalButton = () => (
-    <Button data-testid="jar-decompiler" variant="outlined" onClick={() => modalOpen.next(true)}>
-        <JavaOutlined />
-    </Button>
-);
+export const modalOpen = new BehaviorSubject(false);
 
 export const JarDecompilerModal = () => {
     const jar = useObservable(minecraftJar);
@@ -56,7 +49,7 @@ export const JarDecompilerModal = () => {
 
     const clearCache = () => {
         if (!jar) return;
-        void deleteCache().then(c => messageApi.open({ type: "success", content: `Deleted ${c} clasess from cache.` }));
+        void deleteCache().then(c => messageApi.open({ type: "success", content: `Deleted ${c} classes from cache.` }));
     };
 
     return (
@@ -85,7 +78,6 @@ export const JarDecompilerModal = () => {
                     </Popconfirm>
                 </Form.Item>
             </Form>
-
         </Modal>
     );
 };

--- a/src/ui/SettingsModal.tsx
+++ b/src/ui/SettingsModal.tsx
@@ -1,26 +1,71 @@
-import { Button, Modal, type CheckboxProps, Form, Tooltip, InputNumber, type InputNumberProps, Space } from "antd";
-import { SettingOutlined, SunOutlined, MoonOutlined, DesktopOutlined } from '@ant-design/icons';
+import { Button, Flex, Modal, type CheckboxProps, Form, Tooltip, InputNumber, type InputNumberProps, Space, Tabs } from "antd";
+import { SettingOutlined, SunOutlined, MoonOutlined, DesktopOutlined, JavaOutlined } from '@ant-design/icons';
 import { Checkbox } from 'antd';
 import { useObservable } from "../utils/UseObservable";
 import { BooleanSetting, enableTabs, displayLambdas, focusSearch, KeybindSetting, type KeybindValue, bytecode, showStructure, NumberSetting, preferWasmDecompiler, compactPackages, theme, autoJarIndex } from "../logic/Settings";
 import { capturingKeybind, rawKeydownEvent } from "../logic/Keybinds";
 import { BehaviorSubject } from "rxjs";
-import type React from "react";
+import React, { useEffect, useState } from "react";
+import { modalOpen } from "./JarDecompilerModal";
 
 export const settingsModalOpen = new BehaviorSubject<boolean>(false);
 
 export const SettingsModalButton = () => {
     return (
-        <Button type="default" onClick={() => settingsModalOpen.next(true)}>
-            <SettingOutlined />
-        </Button>
+        <Tooltip title="Settings">
+            <Button
+                aria-label="Settings"
+                icon={<SettingOutlined />}
+                type="default"
+                onClick={() => settingsModalOpen.next(true)}
+            />
+        </Tooltip>
     );
 };
 
-const SettingsModal = () => {
-    const isModalOpen = useObservable(settingsModalOpen);
+const SettingsTab = () => {
     const displayLambdasValue = useObservable(displayLambdas.observable);
     const bytecodeValue = useObservable(bytecode.observable);
+
+    return (
+        <div className="settings-tab-content">
+            <Form className="settings-form" layout="horizontal" labelCol={{ span: 9 }} wrapperCol={{ span: 16 }}>
+                <ThemeOption />
+                <BooleanOption setting={enableTabs} title="Enable Tabs" />
+                <BooleanOption setting={compactPackages} title="Compact Packages" tooltip="Collapse packages with one child into one." />
+                <BooleanOption setting={autoJarIndex} title="Auto Jar Index" tooltip="Automatically index class metadata for file icons." />
+                <BooleanOption setting={displayLambdas} title="Lambda Names" tooltip="Display lambda names as inline comments. Does not support permalinking." disabled={bytecodeValue} />
+                <BooleanOption setting={bytecode} title="Show Bytecode" tooltip="Show bytecode instructions alongside decompiled source. Does not support permalinking." disabled={displayLambdasValue} />
+                <BooleanOption setting={preferWasmDecompiler} title="Prefer WASM Decompiler" tooltip="WASM decompiler might be faster than JavaScript." />
+                <KeybindOption setting={focusSearch} title="Focus Search" captureId="focus_search" />
+                <KeybindOption setting={showStructure} title="Show Structure" captureId="show_structure" />
+            </Form>
+        </div>
+    );
+};
+
+const AdvancedTab = () => (
+    <Flex className="settings-tab-content" vertical align="flex-start" gap="small">
+        <Button
+            data-testid="jar-decompiler"
+            icon={<JavaOutlined />}
+            onClick={() => {
+                settingsModalOpen.next(false);
+                modalOpen.next(true);
+            }}
+        >
+            Decompile All
+        </Button>
+    </Flex>
+);
+
+const SettingsModal = () => {
+    const isModalOpen = useObservable(settingsModalOpen);
+    const [activeTab, setActiveTab] = useState("settings");
+
+    useEffect(() => {
+        if (isModalOpen) setActiveTab("settings");
+    }, [isModalOpen]);
 
     return (
         <Modal
@@ -29,17 +74,23 @@ const SettingsModal = () => {
             onCancel={() => settingsModalOpen.next(false)}
             footer={null}
         >
-            <Form layout="horizontal" labelCol={{ span: 9 }} wrapperCol={{ span: 16 }}>
-                <ThemeOption />
-                <BooleanOption setting={enableTabs} title={"Enable Tabs"} />
-                <BooleanOption setting={compactPackages} title={"Compact Packages"} tooltip="Collapse packages with one child into one." />
-                <BooleanOption setting={autoJarIndex} title={"Auto Jar Index"} tooltip="Automatically index class metadata for file icons." />
-                <BooleanOption setting={displayLambdas} title={"Lambda Names"} tooltip="Display lambda names as inline comments. Does not support permalinking." disabled={bytecodeValue} />
-                <BooleanOption setting={bytecode} title={"Show Bytecode"} tooltip="Show bytecode instructions alongside decompiled source. Does not support permalinking." disabled={displayLambdasValue} />
-                <BooleanOption setting={preferWasmDecompiler} title={"Prefer WASM Decompiler"} tooltip="WASM decompiler might be faster than JavaScript."/>
-                <KeybindOption setting={focusSearch} title={"Focus Search"} captureId="focus_search" />
-                <KeybindOption setting={showStructure} title={"Show Structure"} captureId="show_structure" />
-            </Form>
+            <Tabs
+                className="settings-tabs"
+                activeKey={activeTab}
+                onChange={setActiveTab}
+                items={[
+                    {
+                        key: "settings",
+                        label: "Settings",
+                        children: <SettingsTab />,
+                    },
+                    {
+                        key: "advanced",
+                        label: "Advanced",
+                        children: <AdvancedTab />,
+                    },
+                ]}
+            />
         </Modal>
     );
 };

--- a/tests/decompile.spec.ts
+++ b/tests/decompile.spec.ts
@@ -17,17 +17,15 @@ test.describe('Decompilation', () => {
         await page.getByText('ChatFormatting', { exact: true }).click();
         await waitForDecompiledContent(page, 'enum ChatFormatting');
 
-        const modalButton = page.getByTestId('jar-decompiler').first();
-        await modalButton.waitFor();
-        await modalButton.click();
+        await page.getByRole('button', { name: 'Settings' }).click();
+        await page.getByRole('tab', { name: 'Advanced' }).click();
+        await page.getByTestId('jar-decompiler').click();
 
         const splitsInput = page.getByTestId('jar-decompiler-splits').first();
         await splitsInput.waitFor();
         await splitsInput.fill('1');
 
-        const okButton = page.getByTestId('jar-decompiler-ok').first();
-        await okButton.waitFor();
-        await okButton.click();
+        await page.getByTestId('jar-decompiler-ok').click();
 
         const result = page.getByTestId('jar-decompiler-result').first();
         await result.waitFor();


### PR DESCRIPTION
Moves the decompile all button from the header, and gives us space for more options later.

<img width="543" height="199" alt="Screenshot 2026-07-29 at 16 51 51" src="https://github.com/user-attachments/assets/16a8a48e-eab2-4ba9-a9ce-9b4f349dc987" />
<img width="531" height="573" alt="Screenshot 2026-07-29 at 16 51 47" src="https://github.com/user-attachments/assets/223590b5-29b1-4807-bb75-15f5801b12e5" />
