### PR TITLE
Diff sorting

### DIFF
--- a/src/logic/Settings.ts
+++ b/src/logic/Settings.ts
@@ -163,6 +163,7 @@ export const autoJarIndex = new BooleanSetting('auto_jar_index', true);
 export const displayLambdas = new BooleanSetting('display_lambdas', false);
 export const bytecode = new BooleanSetting('bytecode', false);
 export const unifiedDiff = new BooleanSetting('unified_diff', false);
+export const sortDiff = new BooleanSetting('sortDiff', true);
 export const favoriteMinecraftVersions = new StringArraySetting('favorite_minecraft_versions', []);
 export const showSnapshotVersions = new BooleanSetting('show_snapshot_versions', true);
 export const focusSearch = new KeybindSetting('focus_search', 'Ctrl+ ');

--- a/src/ui/diff/DiffViewActions.tsx
+++ b/src/ui/diff/DiffViewActions.tsx
@@ -3,6 +3,7 @@ import {
     CodeOutlined,
     DownOutlined,
     FileTextOutlined,
+    SortAscendingOutlined,
     SplitCellsOutlined,
     UpOutlined,
 } from "@ant-design/icons";
@@ -10,7 +11,7 @@ import { Button, Tooltip } from "antd";
 import { type CSSProperties, useMemo } from "react";
 import { getDiffChanges } from "../../logic/Diff";
 import { isDecompiling } from "../../logic/Decompiler";
-import { bytecode, unifiedDiff } from "../../logic/Settings";
+import {bytecode, sortDiff, unifiedDiff} from "../../logic/Settings";
 import { selectedFile } from "../../logic/State";
 import { openCodeTab } from "../../logic/tabs";
 import { useObservable } from "../../utils/UseObservable";
@@ -70,6 +71,7 @@ export const DiffViewModeButtons = () => {
     const diffChanges = useMemo(() => getDiffChanges(), []);
     const isUnifiedDiff = useObservable(unifiedDiff.observable);
     const isBytecode = useObservable(bytecode.observable);
+    const isSort = useObservable(sortDiff.observable);
     const currentFile = useObservable(selectedFile);
     const changes = useObservable(diffChanges);
     const currentChange = currentFile ? changes?.get(currentFile) : undefined;
@@ -95,6 +97,15 @@ export const DiffViewModeButtons = () => {
                     aria-label={isBytecode ? "Show decompiled code" : "Show bytecode"}
                     aria-pressed={isBytecode}
                     style={hasNoLineChanges ? noLineChangesBytecodeStyle : undefined}
+                />
+            </Tooltip>
+            <Tooltip title={isSort ? "Sort by file name" : "Sort by change"}>
+                <Button
+                    type={isSort ? "primary" : "default"}
+                    icon={<SortAscendingOutlined />}
+                    onClick={() => sortDiff.value = !sortDiff.value}
+                    aria-label={isSort ? "Sort by file name" : "Sort by change"}
+                    aria-pressed={isSort}
                 />
             </Tooltip>
         </>

--- a/src/ui/diff/DiffViewFileList.tsx
+++ b/src/ui/diff/DiffViewFileList.tsx
@@ -14,6 +14,7 @@ import { openCodeTab } from "../../logic/tabs";
 import { useObservable } from "../../utils/UseObservable";
 import { pendingDiffJump } from "./DiffNavigation";
 import { withoutClassExtension, type ClassFilePath } from "../../utils/Names";
+import {sortDiff} from "../../logic/Settings.ts";
 
 const statusColors: Record<ChangeState, string> = {
     modified: "gold",
@@ -51,8 +52,8 @@ const DiffViewFileList = () => {
 };
 
 const DiffChangedFiles = () => {
-    const entries = useMemo(() => combineLatest([getDiffChanges(), searchQuery]).pipe(
-        map(([changesMap, query]) => {
+    const entries = useMemo(() => combineLatest([getDiffChanges(), searchQuery, sortDiff.observable]).pipe(
+        map(([changesMap, query, sortByChange]) => {
             const files = query ? performSearch(query, [...changesMap.keys()]) : [...changesMap.keys()];
             const nextEntries: DiffEntry[] = [];
 
@@ -66,6 +67,8 @@ const DiffChangedFiles = () => {
                     statusInfo: info,
                 });
             }
+
+            nextEntries.sort((first, second) => sortDiffEntries(first, second, sortByChange))
 
             return nextEntries;
         })
@@ -104,6 +107,25 @@ const DiffChangedFiles = () => {
         </div>
     );
 };
+
+function sortDiffEntries(a: DiffEntry, b: DiffEntry, sortByChange: boolean): number {
+    if (sortByChange) {
+        if (a.statusInfo.state === b.statusInfo.state) {
+            return a.file.localeCompare(b.file);
+        }
+        return changeStateToValue(a.statusInfo.state) - changeStateToValue(b.statusInfo.state);
+    } else {
+        return a.file.localeCompare(b.file);
+    }
+}
+
+function changeStateToValue(changeState: ChangeState) : number {
+    switch (changeState) {
+        case "modified": return 0;
+        case "added": return 1;
+        case "deleted": return 2;
+    }
+}
 
 interface DiffFileRowProps {
     entry: DiffEntry;


### PR DESCRIPTION
Adds a button to the diff view to sort the diff entries by change type in the order of modified, then added, then deleted. Also changes the default to sort by file name.

Closes #158 