### PR TITLE
Defer initial Minecraft version selection

### DIFF
--- a/src/logic/MinecraftApi.ts
+++ b/src/logic/MinecraftApi.ts
@@ -3,6 +3,7 @@ import { agreedEula } from "./Settings";
 import { openJar, type Jar } from "../utils/Jar";
 import { selectedMinecraftVersion } from "./State";
 import { remapMinecraftJar } from "../workers/remap/client";
+import { getDefaultVersion } from "./VersionSelection";
 
 import EXPERIMENTAL_VERSIONS from "./experimental_versions.json";
 
@@ -10,7 +11,7 @@ const CACHE_NAME = 'mcsrc-v1';
 const VERSIONS_URL = "https://piston-meta.mojang.com/mc/game/version_manifest_v2.json";
 
 interface VersionsList {
-    versions: VersionListEntry[]
+    versions: VersionListEntry[];
 }
 
 interface VersionListEntry {
@@ -53,14 +54,12 @@ export const minecraftVersions = agreedEula.observable.pipe(
     filter(agreed => agreed),
     switchMap(() => from(fetchVersions())),
     tap(versions => {
-        // On inital load, if we dont have a version selected or the selected version is not valid, default to the latest version.
-        const currentVersion = selectedMinecraftVersion.value;
-        const isValid = currentVersion !== null && versions.some(v => v.id === currentVersion);
+        const defaultVersion = getDefaultVersion(
+            selectedMinecraftVersion.value,
+            versions
+        );
 
-        if (!isValid && versions.length > 0) {
-            // Select the latest stable release version if it exists, otherwise fall back to the latest version
-            const latestRelease = versions.find(v => v.type === "release");
-            const defaultVersion = latestRelease ? latestRelease.id : versions[0].id;
+        if (defaultVersion !== undefined) {
             selectedMinecraftVersion.next(defaultVersion);
         }
     }),
@@ -124,7 +123,7 @@ export function isUnobfuscated(version: VersionListEntry): boolean {
 }
 
 function isSupported(version: VersionListEntry): boolean {
-    if(isUnobfuscated(version)) return true;
+    if (isUnobfuscated(version)) return true;
     // This version was released after the first snapshot with official mappings,
     // but its mappings were never published.
     if (version.id === '1.14_combat-3') return false;

--- a/src/logic/VersionSelection.test.ts
+++ b/src/logic/VersionSelection.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { getDefaultVersion } from "./VersionSelection";
+
+describe("getDefaultVersion", () => {
+    it("does not select a version when none is selected", () => {
+        const versions = [
+            { id: "1.21.8", type: "release" },
+            { id: "26.2", type: "snapshot" },
+        ];
+
+        expect(getDefaultVersion("", versions)).toBeUndefined();
+    });
+
+    it("does not replace a valid selected version", () => {
+        const versions = [
+            { id: "1.21.8", type: "release" },
+            { id: "26.2", type: "snapshot" },
+        ];
+
+        expect(getDefaultVersion("1.21.8", versions)).toBeUndefined();
+    });
+
+    it("defaults an invalid version to the latest release", () => {
+        const versions = [
+            { id: "1.21.8", type: "release" },
+            { id: "26.2", type: "snapshot" },
+        ];
+
+        expect(getDefaultVersion("1.20.1", versions)).toBe("1.21.8");
+    });
+
+    it("does not select a version when the version list is empty", () => {
+        expect(getDefaultVersion("", [])).toBeUndefined();
+    });
+
+});

--- a/src/logic/VersionSelection.ts
+++ b/src/logic/VersionSelection.ts
@@ -1,0 +1,22 @@
+export interface Version {
+    id: string;
+    type: string;
+}
+
+export function getDefaultVersion(
+    currentVersion: string | null,
+    versions: Version[]
+): string | undefined {
+    // Don't automatically select a version on the initial visit.
+    if (currentVersion === "" || versions.length === 0) {
+        return undefined;
+    }
+
+    if (versions.some(v => v.id === currentVersion)) {
+        return undefined;
+    }
+
+    // Select the latest stable release if the selected version is no longer available.
+    const latestRelease = versions.find(v => v.type === "release");
+    return latestRelease ? latestRelease.id : versions[0].id;
+}

--- a/src/ui/VersionSelector.tsx
+++ b/src/ui/VersionSelector.tsx
@@ -43,7 +43,7 @@ function VersionSelector({
     const dividerIndex = filteredVersions.findIndex(version => !favoriteSet.has(version.id));
     const showFavoritesDivider = dividerIndex > 0;
 
-    const selectedVersionId = currentVersion || versions?.[0]?.id;
+    const selectedVersionId = currentVersion || "Select version";
 
     const toggleFavorite = (version: string) => {
         favoriteMinecraftVersions.value = favoriteVersions.includes(version)


### PR DESCRIPTION
## Summary

* Defer automatic Minecraft version selection on initial visit
* Show `Select version` when no version has been selected
* Preserve fallback behavior for invalid versions
* Add unit tests for version selection behavior

## Testing

* `npm test`
* `npm run lint`
* `npm run build`

Closes #180
