### PR TITLE
feat: fix issues with PNPM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "mcsrc",
       "version": "0.0.0",
       "dependencies": {
-        "@ant-design/icons": "^6.3.2",
+        "@ant-design/icons": "6.1.0",
         "@katana-project/zip": "^0.7.1",
         "@monaco-editor/react": "^4.7.0",
         "@run-slicer/vf": "^0.5.0-1.11.2",
@@ -92,14 +92,14 @@
       }
     },
     "node_modules/@ant-design/icons": {
-      "version": "6.3.2",
-      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-6.3.2.tgz",
-      "integrity": "sha512-B6O5a5XJ4wjtNOfZejXYwHW5zvKV5gYkjGf11dHGLEbKn0ABDGndo41+gfIiXyTFhvESj4XTotuud33mUFid0g==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-6.1.0.tgz",
+      "integrity": "sha512-KrWMu1fIg3w/1F2zfn+JlfNDU8dDqILfA5Tg85iqs1lf8ooyGlbkA+TkwfOKKgqpUmAiRY1PTFpuOU2DAIgSUg==",
       "license": "MIT",
       "dependencies": {
-        "@ant-design/colors": "^8.0.1",
-        "@ant-design/icons-svg": "^4.5.0",
-        "@rc-component/util": "^1.11.0",
+        "@ant-design/colors": "^8.0.0",
+        "@ant-design/icons-svg": "^4.4.0",
+        "@rc-component/util": "^1.3.0",
         "clsx": "^2.1.1"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "mcsrc",
       "version": "0.0.0",
       "dependencies": {
+        "@ant-design/icons": "^6.3.2",
         "@katana-project/zip": "^0.7.1",
         "@monaco-editor/react": "^4.7.0",
         "@run-slicer/vf": "^0.5.0-1.11.2",
@@ -91,14 +92,14 @@
       }
     },
     "node_modules/@ant-design/icons": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-6.1.0.tgz",
-      "integrity": "sha512-KrWMu1fIg3w/1F2zfn+JlfNDU8dDqILfA5Tg85iqs1lf8ooyGlbkA+TkwfOKKgqpUmAiRY1PTFpuOU2DAIgSUg==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-6.3.2.tgz",
+      "integrity": "sha512-B6O5a5XJ4wjtNOfZejXYwHW5zvKV5gYkjGf11dHGLEbKn0ABDGndo41+gfIiXyTFhvESj4XTotuud33mUFid0g==",
       "license": "MIT",
       "dependencies": {
-        "@ant-design/colors": "^8.0.0",
-        "@ant-design/icons-svg": "^4.4.0",
-        "@rc-component/util": "^1.3.0",
+        "@ant-design/colors": "^8.0.1",
+        "@ant-design/icons-svg": "^4.5.0",
+        "@rc-component/util": "^1.11.0",
         "clsx": "^2.1.1"
       },
       "engines": {
@@ -110,9 +111,9 @@
       }
     },
     "node_modules/@ant-design/icons-svg": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@ant-design/icons-svg/-/icons-svg-4.4.2.tgz",
-      "integrity": "sha512-vHbT+zJEVzllwP+CM+ul7reTEfBR0vgxFe7+lREAsAA7YGsYpboiq2sQNeQeRvh09GfQgs/GyFEvZpJ9cLXpXA==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons-svg/-/icons-svg-4.5.0.tgz",
+      "integrity": "sha512-1BTUFyKPTBZ53MuTP8s0k5SFEXL7o3VHEOwLgzaoWKwnBeqIcqUtVshc4SKzhI6uACfqhJqBwBUE9FsWR3uULA==",
       "license": "MIT"
     },
     "node_modules/@ant-design/react-slick": {
@@ -162,7 +163,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2743,13 +2743,13 @@
       }
     },
     "node_modules/@rc-component/util": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@rc-component/util/-/util-1.9.0.tgz",
-      "integrity": "sha512-5uW6AfhIigCWeEQDthTozlxiT4Prn6xYQWeO0xokjcaa186OtwPRHBZJ2o0T0FhbjGhZ3vXdbkv0sx3gAYW7Vg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/util/-/util-1.12.0.tgz",
+      "integrity": "sha512-AEjPL8JVdohIITaiXokyjL9WQ6tKWWjAYK9QU16tGNE9JaQABBQy+hA4H2Lup5MgXy9yY3iLrbZJheuU13hTdQ==",
       "license": "MIT",
       "dependencies": {
         "is-mobile": "^5.0.0",
-        "react-is": "^18.2.0"
+        "react-is": "^19.2.7"
       },
       "peerDependencies": {
         "react": ">=18.0.0",
@@ -3262,7 +3262,6 @@
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -3417,7 +3416,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -3428,7 +3426,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3772,7 +3769,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3979,7 +3975,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4042,8 +4037,7 @@
       "version": "1.11.20",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
       "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -4153,7 +4147,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -4715,7 +4708,6 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
       "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
@@ -4827,7 +4819,6 @@
       "integrity": "sha512-4RuJK2jP08XwqtUu+5yhCbxEauCm6tv2MFHKEMsjbosK2+vy5us82oI3VLuHwbNyZG7ekZA26U2LLHnGR4frIA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "tsgolint": "bin/tsgolint.js"
       },
@@ -4982,7 +4973,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4992,7 +4982,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5001,9 +4990,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
+      "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
       "license": "MIT"
     },
     "node_modules/resolve-from": {
@@ -5294,7 +5283,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5326,7 +5314,6 @@
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -5377,7 +5364,6 @@
       "integrity": "sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oxc-project/runtime": "0.115.0",
         "lightningcss": "^1.32.0",
@@ -5597,7 +5583,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint:fix": "oxlint --fix --type-aware --deny-warnings"
   },
   "dependencies": {
-    "@ant-design/icons": "^6.3.2",
+    "@ant-design/icons": "6.1.0",
     "@katana-project/zip": "^0.7.1",
     "@monaco-editor/react": "^4.7.0",
     "@run-slicer/vf": "^0.5.0-1.11.2",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint:fix": "oxlint --fix --type-aware --deny-warnings"
   },
   "dependencies": {
+    "@ant-design/icons": "^6.3.2",
     "@katana-project/zip": "^0.7.1",
     "@monaco-editor/react": "^4.7.0",
     "@run-slicer/vf": "^0.5.0-1.11.2",


### PR DESCRIPTION
adds PNPM-specific metadata files:
- pnpm-workspace so that esbuild and workerd post-install are approved by default

added @ant-design icons as a top-level dependency because unlike npm, pnpm will refuse to hoist transitive dependencies.

Given this project uses npm by default, it isn't strictly necessary to commit the lock and workspace files, as those can be left untracked I can remove them. The package.json change however would be ideal if it can be accepted so that one doesn't have to be left with unstaged changes to the package.json when using pnpm as package manager